### PR TITLE
Add ACC header group and mapping for CoM/AngAcc; update DISPLAY_RESULT_COLUMNS and converter rules

### DIFF
--- a/src/config/data_columns.py
+++ b/src/config/data_columns.py
@@ -107,6 +107,7 @@ class DisplayNames:
 class HeaderL1:
     POS: str = "Position"
     VEL: str = "Velocity"
+    ACC: str = "Acceleration"
     POSE: str = "Pose"
     INFO: str = "Info"
     ETC: str = "Etc"
@@ -138,6 +139,9 @@ class HeaderL3:
     WX: str = "WX"
     WY: str = "WY"
     WZ: str = "WZ"
+    AX: str = "AX"
+    AY: str = "AY"
+    AZ: str = "AZ"
     TX: str = "TX"
     TY: str = "TY"
     TZ: str = "TZ"
@@ -154,14 +158,19 @@ class HeaderL3:
     SRC: str = "Source"
     NORM_V: str = "Norm_V"
     NORM_W: str = "Norm_W"
+    NORM_A: str = "Norm_A"
     VX_ANA: str = "VX_Ana"
     VY_ANA: str = "VY_Ana"
     VZ_ANA: str = "VZ_Ana"
     WX_ANA: str = "WX_Ana"
     WY_ANA: str = "WY_Ana"
     WZ_ANA: str = "WZ_Ana"
+    AX_ANA: str = "AX_Ana"
+    AY_ANA: str = "AY_Ana"
+    AZ_ANA: str = "AZ_Ana"
     NORM_V_ANA: str = "Norm_V_Ana"
     NORM_W_ANA: str = "Norm_W_Ana"
+    NORM_A_ANA: str = "Norm_A_Ana"
     REL_H: str = "RelativeHeight"
     ANALYSIS_INPUT_H: str = "AnalysisInputHeight"
 
@@ -172,16 +181,16 @@ RESULT_TIME_COL = (HeaderL1.INFO, HeaderL2.TIME, HeaderL3.TIME)
 # This helps to avoid cluttering the view with too many options.
 DISPLAY_RESULT_COLUMNS = [
     # Analysis results for Center of Mass (CoM) Velocity
-    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VX_ANA),
-    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VY_ANA),
-    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VZ_ANA),
-    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.NORM_V_ANA),
+    (HeaderL1.ACC, HeaderL2.COM, HeaderL3.AX_ANA),
+    (HeaderL1.ACC, HeaderL2.COM, HeaderL3.AY_ANA),
+    (HeaderL1.ACC, HeaderL2.COM, HeaderL3.AZ_ANA),
+    (HeaderL1.ACC, HeaderL2.COM, HeaderL3.NORM_A_ANA),
 
     # Analysis results for Angular Velocity
-    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WX_ANA),
-    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WY_ANA),
-    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WZ_ANA),
-    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.NORM_W_ANA),
+    (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.AX_ANA),
+    (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.AY_ANA),
+    (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.AZ_ANA),
+    (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.NORM_A_ANA),
 
     # Relative Height for each of the 8 corners
     (HeaderL1.ANALYSIS, "C1", HeaderL3.REL_H),

--- a/src/utils/header_converter.py
+++ b/src/utils/header_converter.py
@@ -19,6 +19,10 @@ def get_conversion_rules() -> list:
         PoseCols.R_PREFIX,
         VelocityCols.COM_V_PREFIX,
         VelocityCols.ANG_W_PREFIX,
+        'CoM_A',
+        'AngAcc_A',
+        'CoM_A_Norm',
+        'AngAcc_A_Norm',
         VelocityCols.COM_V_NORM,
         VelocityCols.ANG_W_NORM,
         RigidBodyCols.BASE_NAME,
@@ -62,6 +66,28 @@ def get_conversion_rules() -> list:
         # 예시: 'AngVel_W_Norm_Ana' -> ('Velocity', 'CoM', 'Norm_W_Ana')
         (re.compile(f"^{AnalysisCols.ANG_W_NORM_ANA}$"),
          lambda m: (HeaderL1.VEL, HeaderL2.COM, f"{HeaderL3.NORM_W}_Ana")),
+
+        # --- Level 1: Acceleration ---
+        # 예시: 'CoM_Ax', 'CoM_Ax_Ana' -> ('Acceleration', 'CoM', 'AX'/'AX_Ana')
+        (re.compile(r"^CoM_A(?P<axis>[xyz])(?P<ana>_Ana)?$"),
+         lambda m: (
+             HeaderL1.ACC,
+             HeaderL2.COM,
+             f"A{m.group('axis').upper()}{m.group('ana') or ''}"
+         )),
+        # 예시: 'AngAcc_Ax', 'AngAcc_Ax_Ana' -> ('Acceleration', 'Angular', 'AX'/'AX_Ana')
+        (re.compile(r"^AngAcc_A(?P<axis>[xyz])(?P<ana>_Ana)?$"),
+         lambda m: (
+             HeaderL1.ACC,
+             HeaderL2.ANG,
+             f"A{m.group('axis').upper()}{m.group('ana') or ''}"
+         )),
+        # 예시: 'CoM_A_Norm', 'CoM_A_Norm_Ana' -> ('Acceleration', 'CoM', 'Norm_A'/'Norm_A_Ana')
+        (re.compile(r"^CoM_A_Norm(?P<ana>_Ana)?$"),
+         lambda m: (HeaderL1.ACC, HeaderL2.COM, f"{HeaderL3.NORM_A}{m.group('ana') or ''}")),
+        # 예시: 'AngAcc_A_Norm', 'AngAcc_A_Norm_Ana' -> ('Acceleration', 'Angular', 'Norm_A'/'Norm_A_Ana')
+        (re.compile(r"^AngAcc_A_Norm(?P<ana>_Ana)?$"),
+         lambda m: (HeaderL1.ACC, HeaderL2.ANG, f"{HeaderL3.NORM_A}{m.group('ana') or ''}")),
         # 예시: 'C0_Vx' -> ('Velocity', 'C0', 'VX')
         (re.compile(r"^(?P<corner>C\d+)_V(?P<axis>[xyz])$"),
          lambda m: (HeaderL1.VEL, m.group('corner'), getattr(HeaderL3, f"V{m.group('axis').upper()}"))),

--- a/tests/test_header_converter_acceleration.py
+++ b/tests/test_header_converter_acceleration.py
@@ -1,0 +1,26 @@
+from src.config.data_columns import HeaderL1, HeaderL2, HeaderL3
+from src.utils.header_converter import parse_column_name
+
+
+def test_acceleration_columns_map_to_acc_header_l1():
+    assert parse_column_name("CoM_Ax") == (HeaderL1.ACC, HeaderL2.COM, HeaderL3.AX)
+    assert parse_column_name("CoM_Ay") == (HeaderL1.ACC, HeaderL2.COM, HeaderL3.AY)
+    assert parse_column_name("CoM_Az") == (HeaderL1.ACC, HeaderL2.COM, HeaderL3.AZ)
+    assert parse_column_name("CoM_A_Norm") == (HeaderL1.ACC, HeaderL2.COM, HeaderL3.NORM_A)
+
+    assert parse_column_name("AngAcc_Ax") == (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.AX)
+    assert parse_column_name("AngAcc_Ay") == (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.AY)
+    assert parse_column_name("AngAcc_Az") == (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.AZ)
+    assert parse_column_name("AngAcc_A_Norm") == (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.NORM_A)
+
+
+def test_acceleration_analysis_columns_map_to_acc_header_l1():
+    assert parse_column_name("CoM_Ax_Ana") == (HeaderL1.ACC, HeaderL2.COM, HeaderL3.AX_ANA)
+    assert parse_column_name("CoM_A_Norm_Ana") == (HeaderL1.ACC, HeaderL2.COM, HeaderL3.NORM_A_ANA)
+    assert parse_column_name("AngAcc_Ax_Ana") == (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.AX_ANA)
+    assert parse_column_name("AngAcc_A_Norm_Ana") == (HeaderL1.ACC, HeaderL2.ANG, HeaderL3.NORM_A_ANA)
+
+
+def test_velocity_columns_remain_velocity_header_l1():
+    assert parse_column_name("CoM_Vx") == (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VX)
+    assert parse_column_name("AngVel_Wx") == (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WX)


### PR DESCRIPTION
### Motivation
- Introduce an explicit Acceleration top-level header so acceleration-derived columns are grouped separately from velocity in the multi-header scheme.
- Ensure header-conversion maps existing acceleration column name patterns (`CoM_A*`, `AngAcc_A*`, and their `_Ana`/norm variants) into the new `HeaderL1.ACC` group while leaving velocity mappings unchanged.

### Description
- Added `HeaderL1.ACC = "Acceleration"` and new `HeaderL3` constants for acceleration axes and norms (`AX/AY/AZ`, `Norm_A`, and `_Ana` variants) in `src/config/data_columns.py`.
- Updated `DISPLAY_RESULT_COLUMNS` in `src/config/data_columns.py` to move analysis acceleration entries from `HeaderL1.VEL` into `HeaderL1.ACC`, placing translational acceleration under `HeaderL2.COM` and rotational acceleration under `HeaderL2.ANG`.
- Extended `get_conversion_rules()` in `src/utils/header_converter.py` to include regex rules that map `CoM_Ax`, `CoM_Ax_Ana`, `CoM_A_Norm`, `AngAcc_Ax`, `AngAcc_A_Norm`, and their `_Ana` variants to tuples with `HeaderL1.ACC`; also added these patterns to the reserved prefixes to avoid marker-parsing collisions.
- Added unit tests in `tests/test_header_converter_acceleration.py` that assert acceleration columns map to `HeaderL1.ACC` and that `CoM_V*` / `AngVel_*` continue to map to `HeaderL1.VEL`.

### Testing
- Ran `pytest -q tests/test_header_converter_acceleration.py` without `PYTHONPATH` which initially failed with `ModuleNotFoundError: No module named 'src'` due to environment import path.
- Ran `PYTHONPATH=. pytest -q tests/test_header_converter_acceleration.py` which executed the new tests successfully and reported `3 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69902dd9c7b4832993e2e124f70a9fa3)