### PR TITLE
Add explicit _Ana coordinate-frame handling for pose headers and display columns

### DIFF
--- a/src/config/data_columns.py
+++ b/src/config/data_columns.py
@@ -1,5 +1,13 @@
 from dataclasses import dataclass
 
+
+# Coordinate-frame rule used across analyzer outputs.
+# - Columns ending with `_Ana` are represented in the local analysis coordinate frame.
+# - Columns without `_Ana` are represented in the experiment/world coordinate frame.
+ANA_COORDINATE_SUFFIX = "_Ana"
+LOCAL_COORDINATE_FRAME_NAME = "local"
+EXPERIMENT_COORDINATE_FRAME_NAME = "experiment"
+
 @dataclass(frozen=True)
 class TimeCols:
     TIME: str = "Time"
@@ -141,9 +149,15 @@ class HeaderL3:
     TX: str = "TX"
     TY: str = "TY"
     TZ: str = "TZ"
+    TX_ANA: str = "TX_Ana"
+    TY_ANA: str = "TY_Ana"
+    TZ_ANA: str = "TZ_Ana"
     RX: str = "RX"
     RY: str = "RY"
     RZ: str = "RZ"
+    RX_ANA: str = "RX_Ana"
+    RY_ANA: str = "RY_Ana"
+    RZ_ANA: str = "RZ_Ana"
     NX: str = "NX"
     NY: str = "NY"
     NZ: str = "NZ"
@@ -168,67 +182,75 @@ class HeaderL3:
 # --- Result File Column Constants ---
 RESULT_TIME_COL = (HeaderL1.INFO, HeaderL2.TIME, HeaderL3.TIME)
 
-# List of columns to be displayed in the result analyzer's selection tree.
-# This helps to avoid cluttering the view with too many options.
-DISPLAY_RESULT_COLUMNS = [
-    # Analysis results for Center of Mass (CoM) Velocity
+ANALYSIS_TARGET_RESULT_COLUMNS = [
+    # Analysis-frame CoM velocity
     (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VX_ANA),
     (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VY_ANA),
     (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VZ_ANA),
     (HeaderL1.VEL, HeaderL2.COM, HeaderL3.NORM_V_ANA),
 
-    # Analysis results for Angular Velocity
+    # Analysis-frame angular velocity
     (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WX_ANA),
     (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WY_ANA),
     (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WZ_ANA),
     (HeaderL1.VEL, HeaderL2.COM, HeaderL3.NORM_W_ANA),
 
-    # Relative Height for each of the 8 corners
-    (HeaderL1.ANALYSIS, "C1", HeaderL3.REL_H),
-    (HeaderL1.ANALYSIS, "C2", HeaderL3.REL_H),
-    (HeaderL1.ANALYSIS, "C3", HeaderL3.REL_H),
-    (HeaderL1.ANALYSIS, "C4", HeaderL3.REL_H),
-    (HeaderL1.ANALYSIS, "C5", HeaderL3.REL_H),
-    (HeaderL1.ANALYSIS, "C6", HeaderL3.REL_H),
-    (HeaderL1.ANALYSIS, "C7", HeaderL3.REL_H),
-    (HeaderL1.ANALYSIS, "C8", HeaderL3.REL_H),
-
-    # Corner Velocities for each of the 8 corners
-    (HeaderL1.VEL, "C1", HeaderL3.VX),
-    (HeaderL1.VEL, "C1", HeaderL3.VY),
-    (HeaderL1.VEL, "C1", HeaderL3.VZ),
-    (HeaderL1.VEL, "C2", HeaderL3.VX),
-    (HeaderL1.VEL, "C2", HeaderL3.VY),
-    (HeaderL1.VEL, "C2", HeaderL3.VZ),
-    (HeaderL1.VEL, "C3", HeaderL3.VX),
-    (HeaderL1.VEL, "C3", HeaderL3.VY),
-    (HeaderL1.VEL, "C3", HeaderL3.VZ),
-    (HeaderL1.VEL, "C4", HeaderL3.VX),
-    (HeaderL1.VEL, "C4", HeaderL3.VY),
-    (HeaderL1.VEL, "C4", HeaderL3.VZ),
-    (HeaderL1.VEL, "C5", HeaderL3.VX),
-    (HeaderL1.VEL, "C5", HeaderL3.VY),
-    (HeaderL1.VEL, "C5", HeaderL3.VZ),
-    (HeaderL1.VEL, "C6", HeaderL3.VX),
-    (HeaderL1.VEL, "C6", HeaderL3.VY),
-    (HeaderL1.VEL, "C6", HeaderL3.VZ),
-    (HeaderL1.VEL, "C7", HeaderL3.VX),
-    (HeaderL1.VEL, "C7", HeaderL3.VY),
-    (HeaderL1.VEL, "C7", HeaderL3.VZ),
-    (HeaderL1.VEL, "C8", HeaderL3.VX),
-    (HeaderL1.VEL, "C8", HeaderL3.VY),
-    (HeaderL1.VEL, "C8", HeaderL3.VZ),
-
-    # Analysis Input Height for each of the 8 corners
-    (HeaderL1.ANALYSIS_SCENARIO, "C1", HeaderL3.ANALYSIS_INPUT_H),
-    (HeaderL1.ANALYSIS_SCENARIO, "C2", HeaderL3.ANALYSIS_INPUT_H),
-    (HeaderL1.ANALYSIS_SCENARIO, "C3", HeaderL3.ANALYSIS_INPUT_H),
-    (HeaderL1.ANALYSIS_SCENARIO, "C4", HeaderL3.ANALYSIS_INPUT_H),
-    (HeaderL1.ANALYSIS_SCENARIO, "C5", HeaderL3.ANALYSIS_INPUT_H),
-    (HeaderL1.ANALYSIS_SCENARIO, "C6", HeaderL3.ANALYSIS_INPUT_H),
-    (HeaderL1.ANALYSIS_SCENARIO, "C7", HeaderL3.ANALYSIS_INPUT_H),
-    (HeaderL1.ANALYSIS_SCENARIO, "C8", HeaderL3.ANALYSIS_INPUT_H),
+    # Analysis-frame box pose
+    (HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TX_ANA),
+    (HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TY_ANA),
+    (HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TZ_ANA),
+    (HeaderL1.POSE, HeaderL2.BOX_R, HeaderL3.RX_ANA),
+    (HeaderL1.POSE, HeaderL2.BOX_R, HeaderL3.RY_ANA),
+    (HeaderL1.POSE, HeaderL2.BOX_R, HeaderL3.RZ_ANA),
 ]
+
+NON_ANALYSIS_TARGET_RESULT_COLUMNS = [
+    # Experiment-frame box pose
+    (HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TX),
+    (HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TY),
+    (HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TZ),
+    (HeaderL1.POSE, HeaderL2.BOX_R, HeaderL3.RX),
+    (HeaderL1.POSE, HeaderL2.BOX_R, HeaderL3.RY),
+    (HeaderL1.POSE, HeaderL2.BOX_R, HeaderL3.RZ),
+
+    # Experiment-frame CoM velocity
+    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VX),
+    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VY),
+    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VZ),
+    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.NORM_V),
+
+    # Experiment-frame angular velocity
+    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WX),
+    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WY),
+    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.WZ),
+    (HeaderL1.VEL, HeaderL2.COM, HeaderL3.NORM_W),
+]
+
+CORNER_RELATIVE_HEIGHT_RESULT_COLUMNS = [
+    (HeaderL1.ANALYSIS, f"C{i}", HeaderL3.REL_H)
+    for i in range(1, 9)
+]
+
+CORNER_VELOCITY_RESULT_COLUMNS = [
+    (HeaderL1.VEL, f"C{i}", axis)
+    for i in range(1, 9)
+    for axis in (HeaderL3.VX, HeaderL3.VY, HeaderL3.VZ)
+]
+
+ANALYSIS_INPUT_HEIGHT_RESULT_COLUMNS = [
+    (HeaderL1.ANALYSIS_SCENARIO, f"C{i}", HeaderL3.ANALYSIS_INPUT_H)
+    for i in range(1, 9)
+]
+
+# List of columns to be displayed in the result analyzer's selection tree.
+# This helps to avoid cluttering the view with too many options.
+DISPLAY_RESULT_COLUMNS = (
+    ANALYSIS_TARGET_RESULT_COLUMNS
+    + NON_ANALYSIS_TARGET_RESULT_COLUMNS
+    + CORNER_RELATIVE_HEIGHT_RESULT_COLUMNS
+    + CORNER_VELOCITY_RESULT_COLUMNS
+    + ANALYSIS_INPUT_HEIGHT_RESULT_COLUMNS
+)
 
 # --- Corner Name Mapping ---
 CORNER_NAME_MAP = {

--- a/src/utils/header_converter.py
+++ b/src/utils/header_converter.py
@@ -2,7 +2,8 @@ import pandas as pd
 import re
 from typing import Tuple
 from src.config.data_columns import (
-    HeaderL1, HeaderL2, HeaderL3, RigidBodyCols, VelocityCols, PoseCols, AnalysisCols, TimeCols
+    HeaderL1, HeaderL2, HeaderL3, RigidBodyCols, VelocityCols, PoseCols, AnalysisCols, TimeCols,
+    ANA_COORDINATE_SUFFIX
 )
 
 # --- 멀티헤더 변환 규칙 ---
@@ -33,9 +34,15 @@ def get_conversion_rules() -> list:
         # 예시: 'Box_Tx' -> ('Pose', 'BoxTranslation', 'TX')
         (re.compile(f"^{PoseCols.T_PREFIX}(?P<axis>[xyz])$"),
          lambda m: (HeaderL1.POSE, HeaderL2.BOX_T, getattr(HeaderL3, f"T{m.group('axis').upper()}"))),
+        # 예시: 'Box_Tx_Ana' -> ('Pose', 'BoxTranslation', 'TX_Ana')
+        (re.compile(f"^{PoseCols.T_PREFIX}(?P<axis>[xyz]){ANA_COORDINATE_SUFFIX}$"),
+         lambda m: (HeaderL1.POSE, HeaderL2.BOX_T, f"T{m.group('axis').upper()}{ANA_COORDINATE_SUFFIX}")),
         # 예시: 'Box_Rx' -> ('Pose', 'BoxRotation', 'RX')
         (re.compile(f"^{PoseCols.R_PREFIX}(?P<axis>[xyz])$"),
          lambda m: (HeaderL1.POSE, HeaderL2.BOX_R, getattr(HeaderL3, f"R{m.group('axis').upper()}"))),
+        # 예시: 'Box_Rx_Ana' -> ('Pose', 'BoxRotation', 'RX_Ana')
+        (re.compile(f"^{PoseCols.R_PREFIX}(?P<axis>[xyz]){ANA_COORDINATE_SUFFIX}$"),
+         lambda m: (HeaderL1.POSE, HeaderL2.BOX_R, f"R{m.group('axis').upper()}{ANA_COORDINATE_SUFFIX}")),
 
         # --- Level 1: Velocity ---
         # 예시: 'CoM_Vx' -> ('Velocity', 'CoM', 'VX')

--- a/tests/test_header_converter.py
+++ b/tests/test_header_converter.py
@@ -1,0 +1,56 @@
+import unittest
+
+from src.config.data_columns import (
+    DISPLAY_RESULT_COLUMNS,
+    HeaderL1,
+    HeaderL2,
+    HeaderL3,
+)
+from src.utils.header_converter import parse_column_name
+
+
+class TestHeaderConverter(unittest.TestCase):
+    def test_same_quantity_ana_and_non_ana_map_to_different_headers(self):
+        self.assertEqual(
+            parse_column_name("CoM_Vx"),
+            (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VX),
+        )
+        self.assertEqual(
+            parse_column_name("CoM_Vx_Ana"),
+            (HeaderL1.VEL, HeaderL2.COM, HeaderL3.VX_ANA),
+        )
+
+    def test_pose_t_r_ana_pattern_uses_same_rule(self):
+        self.assertEqual(
+            parse_column_name("Box_Tx"),
+            (HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TX),
+        )
+        self.assertEqual(
+            parse_column_name("Box_Tx_Ana"),
+            (HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TX_ANA),
+        )
+
+        self.assertEqual(
+            parse_column_name("Box_Rz"),
+            (HeaderL1.POSE, HeaderL2.BOX_R, HeaderL3.RZ),
+        )
+        self.assertEqual(
+            parse_column_name("Box_Rz_Ana"),
+            (HeaderL1.POSE, HeaderL2.BOX_R, HeaderL3.RZ_ANA),
+        )
+
+    def test_display_result_columns_separate_ana_and_non_ana_targets(self):
+        self.assertIn((HeaderL1.VEL, HeaderL2.COM, HeaderL3.VX), DISPLAY_RESULT_COLUMNS)
+        self.assertIn((HeaderL1.VEL, HeaderL2.COM, HeaderL3.VX_ANA), DISPLAY_RESULT_COLUMNS)
+        self.assertIn((HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TX), DISPLAY_RESULT_COLUMNS)
+        self.assertIn((HeaderL1.POSE, HeaderL2.BOX_T, HeaderL3.TX_ANA), DISPLAY_RESULT_COLUMNS)
+
+        self.assertEqual(
+            len(DISPLAY_RESULT_COLUMNS),
+            len(set(DISPLAY_RESULT_COLUMNS)),
+            "DISPLAY_RESULT_COLUMNS contains duplicated entries.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Standardize how analysis-vs-experiment coordinate frames are represented so `_Ana` columns are unambiguously local/analysis-frame while non-`_Ana` remain experiment/world-frame.
- Ensure pose `Box_T*` / `Box_R*` naming follows the same `_Ana` convention already used for velocities and other analysis outputs.
- Prevent omissions and accidental duplicates in the result selection tree by making `_Ana` and non-`_Ana` targets explicit.

### Description

- Added coordinate-frame constants `ANA_COORDINATE_SUFFIX`, `LOCAL_COORDINATE_FRAME_NAME`, and `EXPERIMENT_COORDINATE_FRAME_NAME` in `src/config/data_columns.py` and documented the rule for `_Ana` vs non-`_Ana` columns.
- Extended `HeaderL3` with `_Ana` variants for pose axes (`TX_ANA`, `TY_ANA`, `TZ_ANA`, `RX_ANA`, `RY_ANA`, `RZ_ANA`).
- Refactored the display column list by introducing grouped lists (`ANALYSIS_TARGET_RESULT_COLUMNS`, `NON_ANALYSIS_TARGET_RESULT_COLUMNS`, `CORNER_RELATIVE_HEIGHT_RESULT_COLUMNS`, `CORNER_VELOCITY_RESULT_COLUMNS`, `ANALYSIS_INPUT_HEIGHT_RESULT_COLUMNS`) and composing them into `DISPLAY_RESULT_COLUMNS` to explicitly separate analysis-frame and experiment-frame entries.
- Updated `src/utils/header_converter.py` to include `_Ana` parsing rules for pose names so `Box_Tx_Ana`/`Box_Rx_Ana` map to the corresponding `_Ana` `HeaderL3` entries using the same pattern as velocity `_Ana` rules.
- Added unit tests in `tests/test_header_converter.py` to verify that `_Ana` and non-`_Ana` variants of the same physical quantity map to different headers, that `Box_T*/Box_R*` `_Ana` patterns parse correctly, and that `DISPLAY_RESULT_COLUMNS` contains both variants without duplicates.

### Testing

- Ran the new unit test: `python -m unittest tests.test_header_converter` which executed 3 tests and passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699031f0e6c88329afbf69bcc64e7643)