### PR TITLE
Introduce RAW_DATA_PROCESSING_LAYOUT constants and apply to Step 1 processing UI

### DIFF
--- a/docs/analysis/design/processing_mode_implementation_plan.md
+++ b/docs/analysis/design/processing_mode_implementation_plan.md
@@ -1,4 +1,4 @@
-Last Reviewed: 2026-03-09
+Last Reviewed: 2026-03-10
 
 # Processing Mode Implementation Plan
 
@@ -195,3 +195,9 @@ Last Reviewed: 2026-03-09
 - 먼저 2단계까지 구현하고 사용 가능한 흐름을 만든다.
 - method 분리와 수치 파라미터 편집은 그 다음 단계로 분리한다.
 - 이번 확장 작업은 작은 단계로 나누어 진행한다.
+
+
+## Layout tuning constants policy (Step 1)
+- Step 1 bottom control row layout tuning values (minimum widths, fixed description height, stretch ratios) are managed in `src/config/config_analysis_ui.py`.
+- `src/analysis/ui/widget_raw_data_processing.py` should consume those constants instead of hard-coded numeric literals.
+- 목적: 해상도/폰트 조건이 달라질 때 코드 로직 수정 없이 설정값만 조정할 수 있도록 유지보수성을 높인다.

--- a/src/analysis/ui/widget_raw_data_processing.py
+++ b/src/analysis/ui/widget_raw_data_processing.py
@@ -2,7 +2,8 @@ import os
 from PySide6.QtCore import Signal, Qt
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
-    QLineEdit, QComboBox, QTextEdit, QGroupBox, QGridLayout, QFileDialog, QRadioButton
+    QLineEdit, QComboBox, QTextEdit, QGroupBox, QGridLayout, QFileDialog, QRadioButton,
+    QSizePolicy
 )
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
@@ -137,6 +138,9 @@ class WidgetRawDataProcessing(QWidget):
 
         processing_group = QGroupBox(config_analysis_ui.PROCESSING_MODE_GROUP_TITLE)
         processing_layout = QVBoxLayout(processing_group)
+        processing_group.setMinimumWidth(
+            config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["processing_group_min_width"]
+        )
 
         radio_row = QHBoxLayout()
         self.rb_processing_standard = QRadioButton(
@@ -156,15 +160,30 @@ class WidgetRawDataProcessing(QWidget):
 
         self.processing_settings_button = QPushButton(config_analysis_ui.ADVANCED_BUTTON_TEXT)
         self.processing_settings_button.setEnabled(False)
+        self.processing_settings_button.setMinimumWidth(
+            config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["processing_settings_button_min_width"]
+        )
+        self.processing_settings_button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         radio_row.addWidget(self.processing_settings_button)
         processing_layout.addLayout(radio_row)
 
         self.processing_mode_description = QLabel()
         self.processing_mode_description.setWordWrap(True)
         self.processing_mode_description.setStyleSheet("color: #4a5568;")
+        self.processing_mode_description.setFixedHeight(
+            config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["processing_mode_description_fixed_height"]
+        )
+        self.processing_mode_description.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         processing_layout.addWidget(self.processing_mode_description)
         h_controls_layout.addWidget(processing_group)
 
+        # Keep bottom controls stable across processing mode text changes.
+        plot_options_group.setMinimumWidth(
+            config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["plot_options_group_min_width"]
+        )
+        self.slice_group.setMinimumWidth(
+            config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["slice_group_min_width"]
+        )
         # Run/Export Buttons
         run_button_layout = QVBoxLayout()
         self.run_button = QPushButton("Run Analysis")
@@ -173,6 +192,11 @@ class WidgetRawDataProcessing(QWidget):
         run_button_layout.addWidget(self.run_button)
         run_button_layout.addWidget(self.export_button)
         h_controls_layout.addLayout(run_button_layout)
+
+        # Stretch mapping order:
+        #   0: plot_options_group, 1: slice_group, 2: processing_group, 3: run_button_layout
+        for index, stretch in enumerate(config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["bottom_controls_stretch"]):
+            h_controls_layout.setStretch(index, stretch)
 
         group_layout.addWidget(controls_widget)
         layout.addWidget(group_box)

--- a/src/config/config_analysis_ui.py
+++ b/src/config/config_analysis_ui.py
@@ -20,6 +20,17 @@ PROCESSING_MODE_DESCRIPTIONS = {
     PROCESSING_MODE_ADVANCED: "Advanced lets you customize each processing stage.",
 }
 
+
+# Step 1 layout tuning constants (Raw Data Processing bottom controls)
+RAW_DATA_PROCESSING_LAYOUT = {
+    "plot_options_group_min_width": 360,
+    "slice_group_min_width": 280,
+    "processing_group_min_width": 360,
+    "processing_mode_description_fixed_height": 42,
+    "bottom_controls_stretch": [4, 3, 4, 2],
+    "processing_settings_button_min_width": 170,
+}
+
 SECTION_TITLES = {
     "marker_smoothing": "Marker Smoothing",
     "range_edge_handling": "Range Edge Handling",


### PR DESCRIPTION
### Motivation
- Centralize layout tuning values for the Step 1 bottom control row to avoid hard-coded numeric literals in the UI and make per-resolution/font tuning easier.
- Apply those constants to the Raw Data Processing widget so processing-mode text or localization changes won't shift adjacent controls.
- Record the layout tuning policy in the design doc and update the doc review date.

### Description
- Add `RAW_DATA_PROCESSING_LAYOUT` constants to `src/config/config_analysis_ui.py` containing minimum widths, fixed description height, stretch ratios, and advanced-button width. 
- Update `src/analysis/ui/widget_raw_data_processing.py` to import `QSizePolicy` and consume the new constants: set minimum widths for `processing_group`, `plot_options_group`, and `slice_group`, set fixed height and size policy for `processing_mode_description`, and set minimum width and fixed size policy for `processing_settings_button`.
- Add a stretch mapping loop to `widget_raw_data_processing.py` that applies `bottom_controls_stretch` values to the bottom controls layout to stabilize control spacing.
- Update `docs/analysis/design/processing_mode_implementation_plan.md` to bump the last-reviewed date and add the "Layout tuning constants policy (Step 1)" section describing where the constants live and how the widget should consume them.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af587a66f48329996143a8dd9632fa)