### PR TITLE
feat: Update animation time display and plot X-axis to time

### DIFF
--- a/src/visualization/animation_widget.py
+++ b/src/visualization/animation_widget.py
@@ -39,7 +39,7 @@ class AnimationWidget(QWidget):
         self.timeline_slider.setRange(0, max_frames - 1)
 
     def update_frame_display(self, frame_number, total_frames, time_value):
-        self.frame_label.setText(f"Frame: {frame_number} / {total_frames}  (Time: {time_value:.2f}s)")
+        self.frame_label.setText(f"Frame: {frame_number} / {total_frames}  (Time: {time_value:.3f}s)")
         self.timeline_slider.blockSignals(True)
         self.timeline_slider.setValue(frame_number)
         self.timeline_slider.blockSignals(False)

--- a/src/visualization/control_panel.py
+++ b/src/visualization/control_panel.py
@@ -106,7 +106,7 @@ class ControlPanel(QWidget):
 
     def update_frame_display(self, frame_number, total_frames, time_value):
         """Updates the frame label and slider position."""
-        self.frame_label.setText(f"Frame: {frame_number} / {total_frames}  (Time: {time_value:.2f}s)")
+        self.frame_label.setText(f"Frame: {frame_number} / {total_frames}  (Time: {time_value:.3f}s)")
         self.timeline_slider.blockSignals(True)
         self.timeline_slider.setValue(frame_number)
         self.timeline_slider.blockSignals(False)

--- a/src/visualization/main_window.py
+++ b/src/visualization/main_window.py
@@ -231,7 +231,7 @@ class MainWindow(QMainWindow):
                     ]
 
                 plot_args.append({
-                    "x": plot_df[config.DF_FRAME],
+                    "x": plot_df[config.DF_TIME],
                     "y": plot_df[data_to_plot],
                     "label": obj_id
                 })

--- a/src/visualization/plot_dialog.py
+++ b/src/visualization/plot_dialog.py
@@ -43,7 +43,7 @@ class PlotDialog(QWidget):
         for args in plot_args:
             self.ax.plot(args["x"], args["y"], label=args["label"])
         self.ax.set_title(f"{y_axis_label} Timeseries (Detailed View)")
-        self.ax.set_xlabel("Frame")
+        self.ax.set_xlabel("Time (s)")
         self.ax.set_ylabel(y_axis_label)
         if len(plot_args) > 1:
             self.ax.legend()
@@ -81,7 +81,7 @@ class PlotDialog(QWidget):
 
         if closest_artist:
             # Update annotation text and position
-            text = f"{closest_artist['line'].get_label()}: ({closest_artist['x']:.0f}, {closest_artist['y']:.2f})"
+            text = f"{closest_artist['line'].get_label()}: ({closest_artist['x']:.3f}, {closest_artist['y']:.2f})"
             self.annot.xy = (closest_artist['x'], closest_artist['y'])
             self.annot.set_text(text)
             self.annot.set_visible(True)

--- a/src/visualization/plot_widget.py
+++ b/src/visualization/plot_widget.py
@@ -42,7 +42,7 @@ class PlotWidget(QWidget):
             self.ax.plot(args["x"], args["y"], label=args["label"])
 
         self.ax.set_title(f"{y_axis_label} Timeseries")
-        self.ax.set_xlabel("Frame")
+        self.ax.set_xlabel("Time (s)")
         self.ax.set_ylabel(y_axis_label)
 
         # Add a legend only if there are multiple lines to distinguish


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR addresses user requests regarding the 3D visualization module's GUI. Specifically, it improves the precision of the time displayed next to the play button during animation by showing it to three decimal places. Additionally, it changes the X-axis of the timeseries plot functionality to represent "Time" rather than "Frame", providing a more intuitive and accurate representation of the data over time.

- 애니메이션 재생 시 표시되는 시간(Time)을 소수점 둘째 자리에서 셋째 자리로 변경
- 시계열 데이터 플랏(Plot) 기능의 X축 기준을 프레임(Frame)에서 시간(Time)으로 변경
- 관련 UI 및 툴팁 문구 (Time (s), 소수점 표기 등) 일괄 수정

**Which issue(s) this PR fixes:**
None

**Special notes for your reviewer:**
- Changes were verified statically and via headless tests to prevent GUI-related system hangs during validation.
- Both `plot_widget` (main summary graph) and `plot_dialog` (detailed popup graph) were updated for consistency.

---
*PR created automatically by Jules for task [10754904692277879985](https://jules.google.com/task/10754904692277879985) started by @pikachu444*