### PR TITLE
Add uniform resampling option to the analysis pipeline

### DIFF
--- a/docs/analysis/design/component_specs.txt
+++ b/docs/analysis/design/component_specs.txt
@@ -2,7 +2,7 @@
 |    컴포넌트 및 기능 명세서 (현재 기준)  |
 =========================================
 
-Last Reviewed: 2026-03-08
+Last Reviewed: 2026-03-11
 
 이 문서는 현재 코드 기준으로 주요 컴포넌트와 책임을 정리한다.
 
@@ -35,6 +35,7 @@ Last Reviewed: 2026-03-08
     *   원본 CSV 로드
     *   미리보기 플롯 표시
     *   박스 크기, 축, 슬라이스 범위 설정
+    *   optional uniform resampling factor 설정
     *   분석 실행 요청
     *   결과 CSV export 요청
 *   주요 UI 요소:
@@ -42,6 +43,7 @@ Last Reviewed: 2026-03-08
     *   `Box Dimensions (mm)`
     *   `Select Data...`
     *   `Slice Range`
+    *   `Resampling`
     *   `Run Analysis`
     *   `Export Results to CSV`
     *   로그 텍스트 영역
@@ -94,14 +96,23 @@ Last Reviewed: 2026-03-08
 ---
 ### 8. `PipelineController`
 ---
-*   위치: `src/analysis/core/pipeline_controller.py`
+*   위치: `src/analysis/pipeline/pipeline_controller.py`
 *   책임:
     *   분석 모듈 호출 순서 제어
     *   로그 / 성공 / 실패 시그널 발행
     *   `parsed_data`를 입력으로 받아 중복 파싱 없이 분석 수행
 
 ---
-### 9. 분석 모듈 집합
+### 9. `UniformResampler`
+---
+*   위치: `src/analysis/pipeline/resampler.py`
+*   책임:
+    *   시간 인덱스를 기준으로 uniform grid 생성
+    *   numeric 컬럼 linear interpolation
+    *   문자열/범주형 컬럼 ffill/bfill
+    *   `Frame` 컬럼 재번호
+---
+### 10. 분석 모듈 집합
 ---
 *   위치: `src/analysis/`
 *   주요 구성:
@@ -112,9 +123,10 @@ Last Reviewed: 2026-03-08
     *   `VelocityCalculator`
     *   `FrameAnalyzer`
     *   `Validator`
+    *   `UniformResampler`
 
 ---
-### 10. 컬럼/헤더 단일 진실원
+### 11. 컬럼/헤더 단일 진실원
 ---
 *   위치: `src/config/data_columns.py`
 *   책임:

--- a/docs/analysis/design/gui_overview.md
+++ b/docs/analysis/design/gui_overview.md
@@ -1,6 +1,6 @@
 # Box Motion Analyzer v2.2 GUI 구조 설명서
 
-Last Reviewed: 2026-03-08
+Last Reviewed: 2026-03-11
 
 ## 개요
 이 문서는 현재 구현된 분석 GUI의 구조를 설명한다. 기준 코드는 `src/analysis/main_window.py`, `src/analysis/ui/widget_raw_data_processing.py`, `src/analysis/ui/widget_results_analyzer.py`이다.
@@ -34,13 +34,20 @@ Last Reviewed: 2026-03-08
 - `Slice Range`
   - 체크 가능한 그룹 박스
   - 활성화 시 `Start`, `End` 입력값과 그래프 구간 선택기가 동기화된다
+- `Resampling`
+  - 분석 전에 uniform time grid로 샘플을 보간할지 결정한다
+  - `Enable Resampling` 체크 시 factor(`2x` ~ `5x`)를 선택할 수 있다
+  - 설명 라벨로 interpolation 기반 시간 해상도 증가 기능임을 안내한다
+- `Processing Mode`
+  - Standard / Raw / Advanced 라디오 버튼
+  - 아래 설명 라벨로 현재 모드의 성격을 안내한다
 - 실행 버튼
   - `Run Analysis`
   - `Export Results to CSV`
 
 ### 2.3. 주요 동작
 - 파일 로드 시 `DataLoader`와 `Parser`가 즉시 미리보기용 데이터를 준비한다.
-- `Run Analysis`는 현재 박스 크기와 슬라이스 범위를 설정 딕셔너리로 만들어 `PipelineController`에 전달한다.
+- `Run Analysis`는 현재 박스 크기, 슬라이스 범위, resampling 옵션, processing mode를 설정 딕셔너리로 만들어 `PipelineController`에 전달한다.
 - `Export Results to CSV`는 최종 분석 결과에 Full/Slice timeline metadata를 추가한 뒤 multi-header CSV로 저장한다.
 - 내보내기 성공 시 저장한 결과 파일을 Step 2에 즉시 로드하고, 탭도 Step 2로 전환한다.
 
@@ -93,8 +100,9 @@ Last Reviewed: 2026-03-08
 ## 4. 현재 사용자 흐름
 1. Step 1에서 원본 CSV를 로드한다.
 2. 필요한 데이터와 축, 슬라이스 범위를 조정한다.
-3. 분석을 실행한다.
-4. 결과를 CSV로 내보낸다.
-5. 저장 직후 Step 2가 열리고 방금 저장한 결과 파일이 자동 로드된다.
-6. Step 2에서 컬럼을 체크하고 메인 플롯 또는 팝업 플롯으로 비교한다.
-7. 특정 시점을 선택하거나 최대값을 찾아 point export 또는 scenario export를 수행한다.
+3. 필요하면 resampling factor를 선택한다.
+4. 분석을 실행한다.
+5. 결과를 CSV로 내보낸다.
+6. 저장 직후 Step 2가 열리고 방금 저장한 결과 파일이 자동 로드된다.
+7. Step 2에서 컬럼을 체크하고 메인 플롯 또는 팝업 플롯으로 비교한다.
+8. 특정 시점을 선택하거나 최대값을 찾아 point export 또는 scenario export를 수행한다.

--- a/docs/analysis/design/system_design.md
+++ b/docs/analysis/design/system_design.md
@@ -1,6 +1,6 @@
 # 소프트웨어 설계 문서 (현재 기준): Box Motion Analyzer GUI
 
-Last Reviewed: 2026-03-08
+Last Reviewed: 2026-03-11
 
 ## 1. 개요
 이 문서는 현재 구현된 Box Motion Analyzer의 분석 GUI 구조를 요약한다. 목표는 원본 CSV 기반 분석 파이프라인과 결과 분석 기능을 하나의 PySide6 애플리케이션 안에서 일관되게 제공하는 것이다.
@@ -25,6 +25,7 @@ Last Reviewed: 2026-03-08
 - 파싱 기반 미리보기 플롯
 - Plot target / axis 선택
 - Slice Range 지정
+- Optional uniform resampling 지정
 - 분석 실행
 - 결과 CSV export
 
@@ -46,6 +47,7 @@ Last Reviewed: 2026-03-08
 ### 4.1. 파이프라인 제어와 UI 분리
 - UI는 설정 수집과 결과 표시를 담당한다.
 - 실제 분석 순서 제어는 `PipelineController`가 담당한다.
+- resampling factor 기반 옵션 보정 규칙처럼 UI/Qt와 무관한 계산 로직은 순수 모듈로 분리한다.
 
 ### 4.2. 컬럼 정의의 중앙 관리
 - 컬럼명, Multi-header 규칙, Results Analyzer 표시 순서는 `src/config/data_columns.py`에서 관리한다.
@@ -54,6 +56,7 @@ Last Reviewed: 2026-03-08
 ### 4.3. 단일 DataFrame 기반 처리
 - 중간 단계마다 파일을 만들지 않고 DataFrame을 누적 확장한다.
 - 최종 결과만 export 단계에서 CSV로 저장한다.
+- resampling을 사용하는 경우에도 slice 이후 DataFrame을 uniform time grid로 재구성한 뒤 후속 분석을 수행한다.
 
 ### 4.4. 분석 결과와 후처리의 분리
 - Step 1은 "계산과 저장"에 집중한다.
@@ -67,6 +70,7 @@ Last Reviewed: 2026-03-08
 - `DataSelectionDialog`
 - `PlotManager`
 - `PipelineController`
+- `UniformResampler`
 - `Parser`, `Slicer`, `Smoother`, `PoseOptimizer`, `VelocityCalculator`, `FrameAnalyzer`
 
 세부 책임은 `component_specs.txt`를 따른다.

--- a/src/analysis/pipeline/pipeline_controller.py
+++ b/src/analysis/pipeline/pipeline_controller.py
@@ -8,6 +8,8 @@ from src.analysis.pipeline.smoother import MarkerSmoother
 from src.analysis.pipeline.pose_optimizer import PoseOptimizer
 from src.analysis.pipeline.velocity_calculator import VelocityCalculator
 from src.analysis.pipeline.frame_analyzer import FrameAnalyzer
+from src.analysis.pipeline.resampling_options import build_effective_analysis_options
+from src.analysis.pipeline.resampler import UniformResampler
 from src.analysis.pipeline.validator import DataValidator
 
 class PipelineController(QObject):
@@ -38,8 +40,14 @@ class PipelineController(QObject):
         try:
             analysis_options = gui_config.get('analysis_options', {})
             processing_mode = gui_config.get('processing_mode', 'standard')
-            self.smoother.configure(analysis_options)
-            self.velocity_calculator.configure(analysis_options)
+            resampling_enabled = bool(gui_config.get('enable_resampling', False))
+            resampling_factor = int(gui_config.get('resampling_factor') or 1)
+            effective_analysis_options = build_effective_analysis_options(
+                analysis_options,
+                resampling_factor if resampling_enabled else 1,
+            )
+            self.smoother.configure(effective_analysis_options)
+            self.velocity_calculator.configure(effective_analysis_options)
 
             self.log_message.emit(f"[INFO] Using Box Dimensions (L,W,H): {config_app.BOX_DIMS}")
             self.log_message.emit(f"[INFO] Processing mode: {processing_mode}")
@@ -88,8 +96,19 @@ class PipelineController(QObject):
             padded_data = slicer_for_padding.process(data)
             self.log_message.emit(f"    Padded slicer done. Shape: {padded_data.shape}")
 
+            if resampling_enabled and resampling_factor > 1:
+                self.log_message.emit("[2.5/8] Resampling data on a uniform time grid...")
+                resampler = UniformResampler(resampling_factor)
+                original_rows = len(padded_data)
+                original_mean_dt = float(pd.Series(padded_data.index).diff().dropna().mean()) if len(padded_data) > 1 else 0.0
+                padded_data = resampler.process(padded_data)
+                new_mean_dt = float(pd.Series(padded_data.index).diff().dropna().mean()) if len(padded_data) > 1 else 0.0
+                self.log_message.emit(f"    Resampling factor: {resampling_factor}x")
+                self.log_message.emit(f"    Rows: {original_rows} -> {len(padded_data)}")
+                self.log_message.emit(f"    Mean dt: {original_mean_dt:.6f}s -> {new_mean_dt:.6f}s")
+
             # 3. 스무딩
-            if analysis_options.get('enable_marker_smoothing', True):
+            if effective_analysis_options.get('enable_marker_smoothing', True):
                 self.log_message.emit("[3/8] Smoothing markers...")
                 data_to_process = self.smoother.process(padded_data)
                 self.log_message.emit(f"    Smoother done. Shape: {data_to_process.shape}")
@@ -98,7 +117,7 @@ class PipelineController(QObject):
                 data_to_process = padded_data.copy()
 
             # --- 전략적 분기점 ---
-            trimming_strategy = analysis_options.get('trimming_strategy', config_analysis.TRIMMING_STRATEGY)
+            trimming_strategy = effective_analysis_options.get('trimming_strategy', config_analysis.TRIMMING_STRATEGY)
             self.log_message.emit(f"\n[INFO] Using Trimming Strategy: '{trimming_strategy}'")
 
             slicer_for_trimming = Slicer(

--- a/src/analysis/pipeline/resampler.py
+++ b/src/analysis/pipeline/resampler.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pandas as pd
+
+from src.config.data_columns import TimeCols
+
+
+class UniformResampler:
+    def __init__(self, factor: int = 2):
+        self.factor = max(1, int(factor))
+
+    def process(self, df: pd.DataFrame) -> pd.DataFrame:
+        if df.empty or self.factor <= 1:
+            return df.copy()
+
+        original_index = df.index.to_numpy(dtype=float)
+        if len(original_index) < 2:
+            return df.copy()
+        if not np.all(np.diff(original_index) > 0):
+            raise ValueError("Resampling requires a strictly increasing time index.")
+
+        new_size = (len(original_index) - 1) * self.factor + 1
+        new_index = np.linspace(original_index[0], original_index[-1], new_size)
+        resampled = pd.DataFrame(index=pd.Index(new_index, name=df.index.name))
+
+        for column in df.columns:
+            series = df[column]
+            numeric_series = pd.to_numeric(series, errors="coerce")
+
+            if numeric_series.notna().any():
+                valid = numeric_series.dropna()
+                if len(valid) == 1:
+                    resampled[column] = np.full(new_size, float(valid.iloc[0]))
+                else:
+                    resampled[column] = np.interp(new_index, valid.index.to_numpy(dtype=float), valid.to_numpy(dtype=float))
+                continue
+
+            expanded = series.reindex(series.index.union(resampled.index)).sort_index()
+            filled = expanded.ffill().bfill()
+            resampled[column] = filled.reindex(resampled.index)
+
+        if TimeCols.FRAME in resampled.columns:
+            resampled[TimeCols.FRAME] = np.arange(len(resampled), dtype=int)
+        else:
+            resampled.insert(0, TimeCols.FRAME, np.arange(len(resampled), dtype=int))
+
+        for column in resampled.columns:
+            if resampled[column].dtype.kind not in {"i", "u", "f"}:
+                resampled[column] = resampled[column].ffill().bfill()
+
+        return resampled

--- a/src/analysis/pipeline/resampling_options.py
+++ b/src/analysis/pipeline/resampling_options.py
@@ -1,0 +1,14 @@
+def build_effective_analysis_options(analysis_options: dict, resampling_factor: int) -> dict:
+    effective = dict(analysis_options)
+    if resampling_factor <= 1:
+        return effective
+
+    for key in ("marker_moving_average_window", "pose_moving_average_window"):
+        if key in effective:
+            effective[key] = max(1, int(round(float(effective[key]) * resampling_factor)))
+
+    for key in ("spline_s_factor_position", "spline_s_factor_rotation"):
+        if key in effective:
+            effective[key] = float(effective[key]) * float(resampling_factor)
+
+    return effective

--- a/src/analysis/ui/widget_raw_data_processing.py
+++ b/src/analysis/ui/widget_raw_data_processing.py
@@ -2,7 +2,7 @@ import os
 from PySide6.QtCore import Signal, Qt
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
-    QLineEdit, QComboBox, QTextEdit, QGroupBox, QGridLayout, QFileDialog, QRadioButton,
+    QLineEdit, QComboBox, QTextEdit, QGroupBox, QGridLayout, QFileDialog, QRadioButton, QCheckBox,
     QSizePolicy
 )
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
@@ -136,6 +136,26 @@ class WidgetRawDataProcessing(QWidget):
         slice_h_layout.addWidget(self.le_slice_end)
         h_controls_layout.addWidget(self.slice_group)
 
+        self.resampling_group = QGroupBox(config_analysis_ui.RESAMPLING_GROUP_TITLE)
+        resampling_layout = QGridLayout(self.resampling_group)
+        self.cb_enable_resampling = QCheckBox(config_analysis_ui.RESAMPLING_ENABLE_LABEL)
+        resampling_layout.addWidget(self.cb_enable_resampling, 0, 0, 1, 2)
+        resampling_layout.addWidget(QLabel(config_analysis_ui.RESAMPLING_FACTOR_LABEL), 1, 0)
+        self.combo_resampling_factor = QComboBox()
+        for label, factor in config_analysis_ui.RESAMPLING_FACTOR_CHOICES:
+            self.combo_resampling_factor.addItem(label, userData=factor)
+        self.combo_resampling_factor.setEnabled(False)
+        resampling_layout.addWidget(self.combo_resampling_factor, 1, 1)
+        self.resampling_description = QLabel(config_analysis_ui.RESAMPLING_DESCRIPTION)
+        self.resampling_description.setWordWrap(True)
+        self.resampling_description.setStyleSheet("color: #4a5568;")
+        self.resampling_description.setFixedHeight(
+            config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["resampling_description_fixed_height"]
+        )
+        self.resampling_description.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        resampling_layout.addWidget(self.resampling_description, 2, 0, 1, 2)
+        h_controls_layout.addWidget(self.resampling_group)
+
         processing_group = QGroupBox(config_analysis_ui.PROCESSING_MODE_GROUP_TITLE)
         processing_layout = QVBoxLayout(processing_group)
         processing_group.setMinimumWidth(
@@ -184,6 +204,9 @@ class WidgetRawDataProcessing(QWidget):
         self.slice_group.setMinimumWidth(
             config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["slice_group_min_width"]
         )
+        self.resampling_group.setMinimumWidth(
+            config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["resampling_group_min_width"]
+        )
         # Run/Export Buttons
         run_button_layout = QVBoxLayout()
         self.run_button = QPushButton("Run Analysis")
@@ -194,7 +217,7 @@ class WidgetRawDataProcessing(QWidget):
         h_controls_layout.addLayout(run_button_layout)
 
         # Stretch mapping order:
-        #   0: plot_options_group, 1: slice_group, 2: processing_group, 3: run_button_layout
+        #   0: plot_options_group, 1: slice_group, 2: resampling_group, 3: processing_group, 4: run_button_layout
         for index, stretch in enumerate(config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["bottom_controls_stretch"]):
             h_controls_layout.setStretch(index, stretch)
 
@@ -211,6 +234,7 @@ class WidgetRawDataProcessing(QWidget):
         self.slice_group.toggled.connect(self.toggle_slicing_widgets)
         self.le_slice_start.editingFinished.connect(self.update_span_selector_from_inputs)
         self.le_slice_end.editingFinished.connect(self.update_span_selector_from_inputs)
+        self.cb_enable_resampling.toggled.connect(self.combo_resampling_factor.setEnabled)
         self.rb_processing_standard.toggled.connect(self._on_processing_mode_changed)
         self.rb_processing_raw.toggled.connect(self._on_processing_mode_changed)
         self.rb_processing_advanced.toggled.connect(self._on_processing_mode_changed)
@@ -365,6 +389,9 @@ class WidgetRawDataProcessing(QWidget):
                 'slice_filter_by': 'time',
                 'slice_start_val': float(self.le_slice_start.text()) if self.slice_group.isChecked() else self.parsed_data.index.min(),
                 'slice_end_val': float(self.le_slice_end.text()) if self.slice_group.isChecked() else self.parsed_data.index.max(),
+                'enable_resampling': self.cb_enable_resampling.isChecked(),
+                'resampling_factor': self.combo_resampling_factor.currentData(),
+                'resampling_method': 'linear',
                 'processing_mode': self.current_processing_mode,
                 'analysis_options': self._build_analysis_overrides(),
             }

--- a/src/config/config_analysis_ui.py
+++ b/src/config/config_analysis_ui.py
@@ -5,8 +5,20 @@ PROCESSING_MODE_RAW = "raw"
 PROCESSING_MODE_ADVANCED = "advanced"
 
 PROCESSING_MODE_GROUP_TITLE = "Processing Mode"
+RESAMPLING_GROUP_TITLE = "Resampling"
 ADVANCED_DIALOG_TITLE = "Advanced Processing Settings"
 ADVANCED_BUTTON_TEXT = "Advanced Settings..."
+RESAMPLING_ENABLE_LABEL = "Enable Resampling"
+RESAMPLING_FACTOR_LABEL = "Factor:"
+RESAMPLING_DESCRIPTION = (
+    "Adds uniformly interpolated samples before analysis to increase temporal resolution."
+)
+RESAMPLING_FACTOR_CHOICES = [
+    ("2x", 2),
+    ("3x", 3),
+    ("4x", 4),
+    ("5x", 5),
+]
 
 PROCESSING_MODE_LABELS = {
     PROCESSING_MODE_STANDARD: "Standard",
@@ -25,9 +37,11 @@ PROCESSING_MODE_DESCRIPTIONS = {
 RAW_DATA_PROCESSING_LAYOUT = {
     "plot_options_group_min_width": 360,
     "slice_group_min_width": 280,
+    "resampling_group_min_width": 280,
     "processing_group_min_width": 360,
     "processing_mode_description_fixed_height": 42,
-    "bottom_controls_stretch": [4, 3, 4, 2],
+    "resampling_description_fixed_height": 42,
+    "bottom_controls_stretch": [4, 3, 3, 4, 2],
     "processing_settings_button_min_width": 170,
 }
 

--- a/tests/test_pipeline_resampling_options.py
+++ b/tests/test_pipeline_resampling_options.py
@@ -1,0 +1,26 @@
+import unittest
+
+from src.analysis.pipeline.resampling_options import build_effective_analysis_options
+
+
+class TestPipelineResamplingOptions(unittest.TestCase):
+    def test_resampling_scales_sample_based_options_and_spline_factors(self):
+        analysis_options = {
+            "marker_moving_average_window": 3,
+            "pose_moving_average_window": 5,
+            "spline_s_factor_position": 1e-2,
+            "spline_s_factor_rotation": 1e-3,
+            "marker_butterworth_cutoff_hz": 10.0,
+        }
+
+        result = build_effective_analysis_options(analysis_options, 4)
+
+        self.assertEqual(result["marker_moving_average_window"], 12)
+        self.assertEqual(result["pose_moving_average_window"], 20)
+        self.assertAlmostEqual(result["spline_s_factor_position"], 4e-2)
+        self.assertAlmostEqual(result["spline_s_factor_rotation"], 4e-3)
+        self.assertEqual(result["marker_butterworth_cutoff_hz"], 10.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from src.analysis.pipeline.resampler import UniformResampler
+from src.config.data_columns import TimeCols
+
+
+class TestUniformResampler(unittest.TestCase):
+    def test_resampler_creates_uniform_grid_and_reindexes_frames(self):
+        df = pd.DataFrame(
+            {
+                TimeCols.FRAME: [10, 11, 12],
+                "RigidBody_Position_X": [0.0, 10.0, 20.0],
+                "Marker_FaceInfo": ["TOP", "TOP", "TOP"],
+            },
+            index=pd.Index([0.0, 0.1, 0.2], name=TimeCols.TIME),
+        )
+
+        result = UniformResampler(factor=2).process(df)
+
+        self.assertEqual(len(result), 5)
+        np.testing.assert_allclose(result.index.to_numpy(), np.array([0.0, 0.05, 0.1, 0.15, 0.2]))
+        np.testing.assert_array_equal(result[TimeCols.FRAME].to_numpy(), np.arange(5))
+        np.testing.assert_allclose(result["RigidBody_Position_X"].to_numpy(), np.array([0.0, 5.0, 10.0, 15.0, 20.0]))
+        self.assertEqual(result["Marker_FaceInfo"].isna().sum(), 0)
+        self.assertTrue((result["Marker_FaceInfo"] == "TOP").all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a uniform resampling option to Step 1 of the analysis UI with 2x to 5x factors
- resample parsed data onto a uniform time grid before smoothing and downstream analysis
- scale sample-based processing options and spline smoothing factors with the selected resampling factor
- update analysis design documents for the new resampling flow

## 한글 요약
- 분석 Step 1 UI에 2x~5x uniform resampling 옵션을 추가했습니다.
- parsing/slice 이후 데이터를 uniform time grid로 보간한 뒤 smoothing과 후속 분석이 진행되도록 구현했습니다.
- resampling factor에 맞춰 moving average window와 spline smoothing factor가 함께 보정되도록 했습니다.
- 관련 분석 설계 문서를 현재 구현에 맞게 갱신했습니다.

## Testing
- python -m unittest tests.test_resampler tests.test_pipeline_resampling_options
- python-pandas installed successfully via tur-repo in Termux for the resampler tests

## Remaining Validation
- PySide6 is not available in this Termux environment, so the actual GUI layout and widget rendering for the new Resampling controls still need to be verified in a desktop environment with PySide6 installed.

## 남은 검증
- 현재 Termux 환경에는 PySide6가 없어, 새로 추가한 Resampling UI의 실제 레이아웃과 위젯 렌더링은 확인하지 못했습니다.
- 따라서 PySide6가 설치된 데스크톱 환경에서 실제 화면 배치와 동작을 한 번 더 검증해야 합니다.