### PR TITLE
Refine Step 1 control panel layout

### DIFF
--- a/src/analysis/ui/widget_raw_data_processing.py
+++ b/src/analysis/ui/widget_raw_data_processing.py
@@ -106,34 +106,45 @@ class WidgetRawDataProcessing(QWidget):
 
         # Plot Options
         plot_options_group = QGroupBox("Plot Options")
-        plot_options_h_layout = QHBoxLayout(plot_options_group)
+        plot_options_layout = QVBoxLayout(plot_options_group)
+        plot_options_top_row = QHBoxLayout()
         self.select_data_button = QPushButton("Select Data...")
         self.selected_data_label = QLabel("Selected: None")
         self.selected_data_label.setWordWrap(True)
-        
-        plot_options_h_layout.addWidget(self.select_data_button)
-        plot_options_h_layout.addWidget(self.selected_data_label)
-        plot_options_h_layout.addWidget(QLabel("Axis:"))
-        
+
+        plot_options_top_row.addWidget(self.select_data_button)
+        plot_options_top_row.addWidget(self.selected_data_label)
+        plot_options_layout.addLayout(plot_options_top_row)
+
+        plot_options_bottom_row = QHBoxLayout()
+        plot_options_bottom_row.addWidget(QLabel("Axis:"))
         self.combo_plot_axis = QComboBox()
         self.combo_plot_axis.addItem("Position-X", userData=PoseCols.POS_X)
         self.combo_plot_axis.addItem("Position-Y", userData=PoseCols.POS_Y)
         self.combo_plot_axis.addItem("Position-Z", userData=PoseCols.POS_Z)
-        plot_options_h_layout.addWidget(self.combo_plot_axis)
-        
+        plot_options_bottom_row.addWidget(self.combo_plot_axis)
+        plot_options_bottom_row.addStretch()
+        plot_options_layout.addLayout(plot_options_bottom_row)
+
         h_controls_layout.addWidget(plot_options_group)
 
         # Slice Range
         self.slice_group = QGroupBox("Slice Range")
         self.slice_group.setCheckable(True)
         self.slice_group.setChecked(False)
-        slice_h_layout = QHBoxLayout(self.slice_group)
-        slice_h_layout.addWidget(QLabel("Start:"))
+        slice_layout = QVBoxLayout(self.slice_group)
+
+        slice_start_row = QHBoxLayout()
+        slice_start_row.addWidget(QLabel("Start:"))
         self.le_slice_start = QLineEdit()
-        slice_h_layout.addWidget(self.le_slice_start)
-        slice_h_layout.addWidget(QLabel("End:"))
+        slice_start_row.addWidget(self.le_slice_start)
+        slice_layout.addLayout(slice_start_row)
+
+        slice_end_row = QHBoxLayout()
+        slice_end_row.addWidget(QLabel("End:"))
         self.le_slice_end = QLineEdit()
-        slice_h_layout.addWidget(self.le_slice_end)
+        slice_end_row.addWidget(self.le_slice_end)
+        slice_layout.addLayout(slice_end_row)
         h_controls_layout.addWidget(self.slice_group)
 
         self.resampling_group = QGroupBox(config_analysis_ui.RESAMPLING_GROUP_TITLE)
@@ -177,15 +188,18 @@ class WidgetRawDataProcessing(QWidget):
         radio_row.addWidget(self.rb_processing_raw)
         radio_row.addWidget(self.rb_processing_advanced)
         radio_row.addStretch()
+        processing_layout.addLayout(radio_row)
 
+        settings_row = QHBoxLayout()
+        settings_row.addStretch()
         self.processing_settings_button = QPushButton(config_analysis_ui.ADVANCED_BUTTON_TEXT)
         self.processing_settings_button.setEnabled(False)
         self.processing_settings_button.setMinimumWidth(
             config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["processing_settings_button_min_width"]
         )
         self.processing_settings_button.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
-        radio_row.addWidget(self.processing_settings_button)
-        processing_layout.addLayout(radio_row)
+        settings_row.addWidget(self.processing_settings_button)
+        processing_layout.addLayout(settings_row)
 
         self.processing_mode_description = QLabel()
         self.processing_mode_description.setWordWrap(True)

--- a/src/config/config_analysis_ui.py
+++ b/src/config/config_analysis_ui.py
@@ -38,11 +38,11 @@ RAW_DATA_PROCESSING_LAYOUT = {
     "plot_options_group_min_width": 360,
     "slice_group_min_width": 280,
     "resampling_group_min_width": 280,
-    "processing_group_min_width": 360,
+    "processing_group_min_width": 320,
     "processing_mode_description_fixed_height": 42,
     "resampling_description_fixed_height": 42,
     "bottom_controls_stretch": [4, 3, 3, 4, 2],
-    "processing_settings_button_min_width": 170,
+    "processing_settings_button_min_width": 150,
 }
 
 SECTION_TITLES = {


### PR DESCRIPTION
## Summary
- split the Processing Mode controls into separate rows for the radio buttons and Advanced Settings button
- split Plot Options into separate rows for data selection and axis selection
- split Slice Range into separate rows for the start and end inputs
- reduce the advanced settings button width and relax the processing group minimum width

### 한글 요약
- Processing Mode 영역에서 라디오 버튼과 Advanced Settings 버튼을 서로 다른 줄로 분리했습니다.
- Plot Options 영역을 데이터 선택 행과 axis 선택 행으로 분리했습니다.
- Slice Range 영역을 Start 입력 행과 End 입력 행으로 분리했습니다.
- Advanced Settings 버튼 폭을 줄이고 Processing Mode 그룹 최소 폭을 완화했습니다.

## Validation
- python -m py_compile src/analysis/ui/widget_raw_data_processing.py src/config/config_analysis_ui.py
- reviewed the updated layout diff for the Step 1 controls

## Notes
- this change focuses on layout resilience and readability when the window width changes
- the live Qt layout was not visually smoke-tested in this environment

### 한글 참고
- 이번 변경은 창 너비 변화에 대한 레이아웃 안정성과 가독성 개선에 초점을 맞췄습니다.
- 현재 환경에서는 실제 Qt GUI를 띄워 화면 배치를 직접 확인하는 시각 검증까지는 수행하지 못했습니다.