### PR TITLE
Add adjustable splitter to Step 1 top layout

### DIFF
--- a/src/analysis/ui/widget_raw_data_processing.py
+++ b/src/analysis/ui/widget_raw_data_processing.py
@@ -3,7 +3,7 @@ from PySide6.QtCore import Signal, Qt
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
     QLineEdit, QComboBox, QTextEdit, QGroupBox, QGridLayout, QFileDialog, QRadioButton, QCheckBox,
-    QSizePolicy
+    QSizePolicy, QSplitter
 )
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
@@ -46,7 +46,7 @@ class WidgetRawDataProcessing(QWidget):
         group_layout = QVBoxLayout(group_box)
 
         # 1a. Top Layout: Plot and Right Panel
-        top_layout = QHBoxLayout()
+        top_splitter = QSplitter(Qt.Orientation.Horizontal)
 
         # Plot Container
         plot_container = QWidget()
@@ -64,9 +64,12 @@ class WidgetRawDataProcessing(QWidget):
         self.plot_manager = PlotManager(self.canvas, self.fig)
         self.plot_manager.ax.text(0.5, 0.5, "Load a CSV file to start.", ha='center', va='center')
         self.plot_manager.canvas.draw()
+        top_splitter.addWidget(plot_container)
 
         # Right Panel
+        right_panel = QWidget()
         right_panel_layout = QVBoxLayout()
+        right_panel.setLayout(right_panel_layout)
         self.load_csv_button = QPushButton("Load CSV File...")
         self.file_path_label = QLabel("No file selected.")
         
@@ -96,9 +99,12 @@ class WidgetRawDataProcessing(QWidget):
         self.log_output.setPlaceholderText("[INFO] Load a CSV file to start.")
         right_panel_layout.addWidget(self.log_output)
 
-        top_layout.addWidget(plot_container, 8)
-        top_layout.addLayout(right_panel_layout, 2)
-        group_layout.addLayout(top_layout)
+        top_splitter.addWidget(right_panel)
+        top_splitter.setChildrenCollapsible(False)
+        top_splitter.setStretchFactor(0, 5)
+        top_splitter.setStretchFactor(1, 2)
+        top_splitter.setSizes([900, 280])
+        group_layout.addWidget(top_splitter)
 
         # 1b. Bottom Controls
         controls_widget = QWidget()


### PR DESCRIPTION
## Summary
- replace the fixed Step 1 top layout with a horizontal splitter
- bias the default splitter size toward the plot panel so wide plots get more space
- keep the right-side controls resizable instead of fixed-width

### 한글 요약
- Step 1 상단의 고정 레이아웃을 가로 splitter 구조로 변경했습니다.
- 기본 splitter 비율을 플롯 영역이 더 넓게 보이도록 조정했습니다.
- 오른쪽 컨트롤 영역은 고정 폭 대신 사용자가 직접 조절할 수 있도록 했습니다.

## Validation
- python -m py_compile src/analysis/ui/widget_raw_data_processing.py
- reviewed the updated layout diff for the Step 1 top area

## Notes
- this change improves plot visibility for wide data while preserving access to the right-side controls
- splitter size persistence across app restarts is not included in this change

### 한글 참고
- 이번 변경은 가로로 긴 데이터를 더 잘 볼 수 있도록 플롯 가시성을 높이는 데 초점을 맞췄습니다.
- splitter 위치를 앱 재실행 후에도 기억하는 기능은 이번 변경에 포함하지 않았습니다.