### PR TITLE
Add Savitzky-Golay marker smoothing option

### DIFF
--- a/docs/analysis/design/system_design.md
+++ b/docs/analysis/design/system_design.md
@@ -29,6 +29,7 @@ Last Reviewed: 2026-03-13
 - 분석 실행
 - 결과 CSV export
 - 미리보기 플롯과 하단 제어 영역 사이에는 세로 splitter가 있어, 창 높이 증가분이 플롯에 우선 배분되고 사용자가 플롯 높이를 직접 조절할 수 있다.
+- Advanced marker smoothing에서는 선택한 method sequence에 따라 관련 파라미터만 표시되며, Savitzky-Golay를 marker smoothing 옵션으로 비교할 수 있다.
 
 ### 3.2. Step 2: Results Analysis
 - 결과 폴더 / 파일 선택

--- a/src/analysis/pipeline/resampling_options.py
+++ b/src/analysis/pipeline/resampling_options.py
@@ -3,7 +3,7 @@ def build_effective_analysis_options(analysis_options: dict, resampling_factor: 
     if resampling_factor <= 1:
         return effective
 
-    for key in ("marker_moving_average_window", "pose_moving_average_window"):
+    for key in ("marker_moving_average_window", "marker_savgol_window_length", "pose_moving_average_window"):
         if key in effective:
             effective[key] = max(1, int(round(float(effective[key]) * resampling_factor)))
 

--- a/src/analysis/pipeline/smoother.py
+++ b/src/analysis/pipeline/smoother.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-from scipy.signal import butter, filtfilt
+from scipy.signal import butter, filtfilt, savgol_filter
 from src.config import config_analysis
 from src.config.data_columns import RawMarkerCols
 
@@ -26,6 +26,17 @@ class MarkerSmoother:
         self.cutoff_freq = settings.get('marker_butterworth_cutoff_hz', config_analysis.BUTTERWORTH_CUTOFF_FREQ_HZ)
         self.order = int(settings.get('marker_butterworth_order', config_analysis.BUTTERWORTH_ORDER))
         self.ma_window = int(settings.get('marker_moving_average_window', config_analysis.MA_WINDOW_SIZE))
+        self.savgol_window_length = int(
+            settings.get('marker_savgol_window_length', config_analysis.SAVGOL_WINDOW_LENGTH)
+        )
+        self.savgol_polyorder = int(
+            settings.get('marker_savgol_polyorder', config_analysis.SAVGOL_POLYORDER)
+        )
+
+    @staticmethod
+    def _normalize_odd_window(window: int) -> int:
+        window = max(1, int(window))
+        return window if window % 2 == 1 else window + 1
 
     def _calculate_fs(self, time_series: pd.Series) -> float:
         """시간 Series로부터 평균 샘플링 주파수를 계산합니다."""
@@ -62,6 +73,32 @@ class MarkerSmoother:
             elif method == 'moving_average':
                 if self.ma_window <= 1 or len(smoothed) < self.ma_window: continue
                 smoothed = smoothed.rolling(window=self.ma_window, center=True, min_periods=1).mean()
+
+            elif method == 'savitzky_golay':
+                window_length = self._normalize_odd_window(self.savgol_window_length)
+                if len(smoothed) < 3:
+                    continue
+                if window_length > len(smoothed):
+                    window_length = len(smoothed) if len(smoothed) % 2 == 1 else len(smoothed) - 1
+                if window_length < 3:
+                    continue
+
+                polyorder = max(1, int(self.savgol_polyorder))
+                if polyorder >= window_length:
+                    polyorder = window_length - 1
+                if polyorder < 1:
+                    continue
+
+                try:
+                    filtered_values = savgol_filter(
+                        smoothed.astype(np.float64).values,
+                        window_length=window_length,
+                        polyorder=polyorder,
+                        mode='interp',
+                    )
+                    smoothed = pd.Series(filtered_values, index=series.index, name=series.name)
+                except ValueError:
+                    continue
 
         return smoothed
 

--- a/src/analysis/ui/dialog_processing_settings.py
+++ b/src/analysis/ui/dialog_processing_settings.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QPushButton,
     QSpinBox,
+    QWidget,
     QVBoxLayout,
 )
 
@@ -44,13 +45,35 @@ class ProcessingSettingsDialog(QDialog):
         for label, value in ui_config.MARKER_SMOOTHING_METHOD_CHOICES:
             self.combo_marker_method.addItem(label, userData=value)
         marker_form.addRow(ui_config.FIELD_LABELS["marker_smoothing_method"], self.combo_marker_method)
+        marker_layout.addLayout(marker_form)
+
+        self.marker_butterworth_group = QGroupBox(ui_config.FIELD_LABELS["marker_butterworth_group"])
+        marker_butterworth_form = QFormLayout(self.marker_butterworth_group)
         self.spin_marker_cutoff = self._create_double_spinbox(0.1, 200.0, 2, 0.5)
         self.spin_marker_order = self._create_int_spinbox(1, 10)
+        marker_butterworth_form.addRow(ui_config.FIELD_LABELS["marker_butterworth_cutoff"], self.spin_marker_cutoff)
+        marker_butterworth_form.addRow(ui_config.FIELD_LABELS["marker_butterworth_order"], self.spin_marker_order)
+        marker_layout.addWidget(self.marker_butterworth_group)
+
+        self.marker_ma_group = QGroupBox(ui_config.FIELD_LABELS["marker_ma_group"])
+        marker_ma_form = QFormLayout(self.marker_ma_group)
         self.spin_marker_ma_window = self._create_int_spinbox(1, 101)
-        marker_form.addRow(ui_config.FIELD_LABELS["marker_butterworth_cutoff"], self.spin_marker_cutoff)
-        marker_form.addRow(ui_config.FIELD_LABELS["marker_butterworth_order"], self.spin_marker_order)
-        marker_form.addRow(ui_config.FIELD_LABELS["marker_ma_window"], self.spin_marker_ma_window)
-        marker_layout.addLayout(marker_form)
+        marker_ma_form.addRow(ui_config.FIELD_LABELS["marker_ma_window"], self.spin_marker_ma_window)
+        marker_layout.addWidget(self.marker_ma_group)
+
+        self.marker_savgol_group = QGroupBox(ui_config.FIELD_LABELS["marker_savgol_group"])
+        marker_savgol_layout = QVBoxLayout(self.marker_savgol_group)
+        marker_savgol_hint = QLabel(ui_config.FIELD_HINTS["marker_savgol"])
+        marker_savgol_hint.setWordWrap(True)
+        marker_savgol_hint.setStyleSheet("color: #718096; font-size: 11px;")
+        marker_savgol_layout.addWidget(marker_savgol_hint)
+        marker_savgol_form = QFormLayout()
+        self.spin_marker_savgol_window = self._create_int_spinbox(3, 201)
+        self.spin_marker_savgol_polyorder = self._create_int_spinbox(1, 10)
+        marker_savgol_form.addRow(ui_config.FIELD_LABELS["marker_savgol_window"], self.spin_marker_savgol_window)
+        marker_savgol_form.addRow(ui_config.FIELD_LABELS["marker_savgol_polyorder"], self.spin_marker_savgol_polyorder)
+        marker_savgol_layout.addLayout(marker_savgol_form)
+        marker_layout.addWidget(self.marker_savgol_group)
         root.addWidget(marker_group)
 
         range_group = QGroupBox(ui_config.SECTION_TITLES["range_edge_handling"])
@@ -185,6 +208,7 @@ class ProcessingSettingsDialog(QDialog):
         self.cb_pose_ma.toggled.connect(self._update_enabled_state)
         self.cb_velocity_lpf.toggled.connect(self._update_enabled_state)
         self.cb_acceleration_lpf.toggled.connect(self._update_enabled_state)
+        self.combo_marker_method.currentIndexChanged.connect(self._update_enabled_state)
         self.combo_velocity_method.currentIndexChanged.connect(self._update_enabled_state)
         self.combo_acceleration_method.currentIndexChanged.connect(self._update_enabled_state)
 
@@ -197,6 +221,8 @@ class ProcessingSettingsDialog(QDialog):
         self.spin_marker_cutoff.setValue(self._current_options.get("marker_butterworth_cutoff_hz", 10.0))
         self.spin_marker_order.setValue(self._current_options.get("marker_butterworth_order", 4))
         self.spin_marker_ma_window.setValue(self._current_options.get("marker_moving_average_window", 3))
+        self.spin_marker_savgol_window.setValue(self._current_options.get("marker_savgol_window_length", 7))
+        self.spin_marker_savgol_polyorder.setValue(self._current_options.get("marker_savgol_polyorder", 3))
         self._set_combo_data(
             self.combo_range_handling,
             self._current_options.get("trimming_strategy", "late"),
@@ -243,12 +269,21 @@ class ProcessingSettingsDialog(QDialog):
         spinbox.setRange(minimum, maximum)
         return spinbox
 
+    def _set_widget_visible(self, widget: QWidget, visible: bool):
+        widget.setVisible(visible)
+        widget.setEnabled(visible)
+
     def _update_enabled_state(self):
         marker_enabled = self.cb_marker_smoothing.isChecked()
         self.combo_marker_method.setEnabled(marker_enabled)
-        self.spin_marker_cutoff.setEnabled(marker_enabled)
-        self.spin_marker_order.setEnabled(marker_enabled)
-        self.spin_marker_ma_window.setEnabled(marker_enabled)
+        selected_methods = list(self.combo_marker_method.currentData() or [])
+        show_butterworth = marker_enabled and "butterworth" in selected_methods
+        show_moving_average = marker_enabled and "moving_average" in selected_methods
+        show_savgol = marker_enabled and "savitzky_golay" in selected_methods
+
+        self._set_widget_visible(self.marker_butterworth_group, show_butterworth)
+        self._set_widget_visible(self.marker_ma_group, show_moving_average)
+        self._set_widget_visible(self.marker_savgol_group, show_savgol)
 
         self.spin_pose_lpf_cutoff.setEnabled(self.cb_pose_lpf.isChecked())
         self.spin_pose_lpf_order.setEnabled(self.cb_pose_lpf.isChecked())
@@ -274,6 +309,8 @@ class ProcessingSettingsDialog(QDialog):
             "marker_butterworth_cutoff_hz": self.spin_marker_cutoff.value(),
             "marker_butterworth_order": self.spin_marker_order.value(),
             "marker_moving_average_window": self.spin_marker_ma_window.value(),
+            "marker_savgol_window_length": self.spin_marker_savgol_window.value(),
+            "marker_savgol_polyorder": self.spin_marker_savgol_polyorder.value(),
             "trimming_strategy": self.combo_range_handling.currentData(),
             "use_pose_lowpass_filter": self.cb_pose_lpf.isChecked(),
             "pose_lpf_cutoff_hz": self.spin_pose_lpf_cutoff.value(),

--- a/src/config/config_analysis.py
+++ b/src/config/config_analysis.py
@@ -13,6 +13,8 @@ BUTTERWORTH_ORDER = 4
 # Scipy의 filtfilt 기본값인 3 * (order + 1)을 따름.
 BUTTERWORTH_PAD_SIZE = 3 * (BUTTERWORTH_ORDER + 1)
 MA_WINDOW_SIZE = 3
+SAVGOL_WINDOW_LENGTH = 7
+SAVGOL_POLYORDER = 3
 
 # 스무딩 시 경계 효과를 줄이기 위한 패딩 사이즈.
 # scipy.signal.filtfilt의 기본 패딩 길이(3 * (order+1))를 따름.

--- a/src/config/config_analysis_ui.py
+++ b/src/config/config_analysis_ui.py
@@ -66,9 +66,14 @@ SECTION_DESCRIPTIONS = {
 FIELD_LABELS = {
     "enable_marker_smoothing": "Enable marker smoothing",
     "marker_smoothing_method": "Method:",
+    "marker_butterworth_group": "Butterworth settings",
     "marker_butterworth_cutoff": "Butterworth cutoff (Hz):",
     "marker_butterworth_order": "Butterworth order:",
+    "marker_ma_group": "Moving average settings",
     "marker_ma_window": "Moving average window:",
+    "marker_savgol_group": "Savitzky-Golay settings",
+    "marker_savgol_window": "Window length:",
+    "marker_savgol_polyorder": "Polynomial order:",
     "range_edge_handling": "Mode:",
     "pose_lowpass_filter": "Pose Butterworth low-pass filter",
     "pose_moving_average": "Pose moving average",
@@ -92,6 +97,7 @@ FIELD_LABELS = {
 
 FIELD_HINTS = {
     "enable_marker_smoothing": "Recommended for standard processing. Disabling this keeps the marker data closer to the raw input.",
+    "marker_savgol": "Savitzky-Golay can preserve local peak shape better than a low-pass filter, but large windows can still smear impact timing.",
     "range_edge_handling": "Stable keeps a small hidden margin around the selected range during calculations. Fast trims earlier and can be less reliable near the boundaries.",
     "pose_lowpass_filter": "Reduces fast pose jitter before derivatives are computed.",
     "pose_moving_average": "Applies a small moving average to pose data for additional stabilization.",
@@ -115,6 +121,7 @@ MARKER_SMOOTHING_METHOD_CHOICES = [
     ("Butterworth -> Moving Average", ["butterworth", "moving_average"]),
     ("Butterworth", ["butterworth"]),
     ("Moving Average", ["moving_average"]),
+    ("Savitzky-Golay", ["savitzky_golay"]),
 ]
 
 
@@ -125,6 +132,8 @@ def get_default_advanced_options():
         "marker_butterworth_cutoff_hz": config_analysis.BUTTERWORTH_CUTOFF_FREQ_HZ,
         "marker_butterworth_order": config_analysis.BUTTERWORTH_ORDER,
         "marker_moving_average_window": config_analysis.MA_WINDOW_SIZE,
+        "marker_savgol_window_length": config_analysis.SAVGOL_WINDOW_LENGTH,
+        "marker_savgol_polyorder": config_analysis.SAVGOL_POLYORDER,
         "trimming_strategy": config_analysis.TRIMMING_STRATEGY,
         "use_pose_lowpass_filter": config_analysis.USE_POSE_LOWPASS_FILTER,
         "pose_lpf_cutoff_hz": config_analysis.POSE_LPF_CUTOFF_HZ,
@@ -152,6 +161,8 @@ def get_raw_mode_options():
         "marker_butterworth_cutoff_hz": config_analysis.BUTTERWORTH_CUTOFF_FREQ_HZ,
         "marker_butterworth_order": config_analysis.BUTTERWORTH_ORDER,
         "marker_moving_average_window": config_analysis.MA_WINDOW_SIZE,
+        "marker_savgol_window_length": config_analysis.SAVGOL_WINDOW_LENGTH,
+        "marker_savgol_polyorder": config_analysis.SAVGOL_POLYORDER,
         "trimming_strategy": "early",
         "use_pose_lowpass_filter": False,
         "pose_lpf_cutoff_hz": config_analysis.POSE_LPF_CUTOFF_HZ,

--- a/tests/test_marker_smoothing_savgol.py
+++ b/tests/test_marker_smoothing_savgol.py
@@ -1,0 +1,94 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from src.analysis.pipeline.resampling_options import build_effective_analysis_options
+from src.analysis.pipeline.smoother import MarkerSmoother
+
+
+class TestMarkerSmoothingSavitzkyGolay(unittest.TestCase):
+    @staticmethod
+    def _make_impulse_like_signal():
+        dt = 0.002
+        time = np.arange(0.0, 1.0, dt)
+        peak_1 = 0.30
+        peak_2 = 0.34
+        sigma = 0.006
+
+        signal = (
+            1.0 * np.exp(-((time - peak_1) ** 2) / (2 * sigma**2))
+            + 0.8 * np.exp(-((time - peak_2) ** 2) / (2 * sigma**2))
+        )
+
+        # Add deterministic high-frequency noise to mimic marker jitter.
+        noise = 0.05 * np.sin(2 * np.pi * 60.0 * time) + 0.02 * np.cos(2 * np.pi * 85.0 * time)
+        df = pd.DataFrame({"Corner1_X": signal + noise}, index=time)
+        return df, peak_1, peak_2
+
+    @staticmethod
+    def _peak_time_in_window(series: pd.Series, start: float, end: float) -> float:
+        window = series[(series.index >= start) & (series.index <= end)]
+        if window.empty:
+            raise AssertionError("Peak search window is empty.")
+        return float(window.idxmax())
+
+    def test_resampling_scales_savgol_window_length(self):
+        analysis_options = {
+            "marker_savgol_window_length": 7,
+            "marker_moving_average_window": 3,
+        }
+
+        result = build_effective_analysis_options(analysis_options, 4)
+
+        self.assertEqual(result["marker_savgol_window_length"], 28)
+        self.assertEqual(result["marker_moving_average_window"], 12)
+
+    def test_savgol_path_runs_and_preserves_peak_spacing_better_than_low_cutoff_butterworth(self):
+        df, peak_1, peak_2 = self._make_impulse_like_signal()
+        expected_spacing = peak_2 - peak_1
+
+        smoother = MarkerSmoother()
+
+        butterworth_options = {
+            "enable_marker_smoothing": True,
+            "marker_smoothing_method_sequence": ["butterworth"],
+            "marker_butterworth_cutoff_hz": 3.0,
+            "marker_butterworth_order": 4,
+        }
+        savgol_options = {
+            "enable_marker_smoothing": True,
+            "marker_smoothing_method_sequence": ["savitzky_golay"],
+            "marker_savgol_window_length": 11,
+            "marker_savgol_polyorder": 3,
+        }
+
+        smoother.configure(butterworth_options)
+        butterworth_df = smoother.process(df)
+
+        smoother.configure(savgol_options)
+        savgol_df = smoother.process(df)
+
+        self.assertFalse(butterworth_df["Corner1_X"].isna().any())
+        self.assertFalse(savgol_df["Corner1_X"].isna().any())
+
+        raw_series = df["Corner1_X"]
+        butterworth_series = butterworth_df["Corner1_X"]
+        savgol_series = savgol_df["Corner1_X"]
+
+        raw_spacing = self._peak_time_in_window(raw_series, 0.27, 0.32)
+        raw_spacing = self._peak_time_in_window(raw_series, 0.32, 0.37) - raw_spacing
+        butterworth_spacing = self._peak_time_in_window(butterworth_series, 0.27, 0.32)
+        butterworth_spacing = self._peak_time_in_window(butterworth_series, 0.32, 0.37) - butterworth_spacing
+        savgol_spacing = self._peak_time_in_window(savgol_series, 0.27, 0.32)
+        savgol_spacing = self._peak_time_in_window(savgol_series, 0.32, 0.37) - savgol_spacing
+
+        self.assertAlmostEqual(raw_spacing, expected_spacing, delta=0.004)
+        self.assertLess(
+            abs(savgol_spacing - expected_spacing),
+            abs(butterworth_spacing - expected_spacing),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
English
- Summary
  - Add Savitzky-Golay as a marker smoothing option and make the Advanced marker smoothing UI show only method-relevant parameters.
- Changes
  - Extend the marker smoother to support the `savitzky_golay` method with window length and polynomial order settings.
  - Add Savitzky-Golay defaults and labels to the analysis configuration.
  - Update the Advanced Processing Settings dialog so Butterworth, Moving Average, and Savitzky-Golay parameter groups are shown only when the selected method sequence uses them.
  - Scale the Savitzky-Golay window length when resampling adjusts sample-based smoothing options.
  - Document the Advanced marker smoothing behavior in the analysis system design doc.
  - Add a numerical regression test that checks the Savitzky-Golay path and compares peak-spacing preservation against a low-cutoff Butterworth filter on synthetic impact-like data.
- Testing
  - Ran `python -m py_compile src/config/config_analysis.py src/config/config_analysis_ui.py src/analysis/pipeline/smoother.py src/analysis/pipeline/resampling_options.py src/analysis/ui/dialog_processing_settings.py`.
  - Installed `pandas` and `scipy` from Ubuntu packages for numerical validation.
  - Ran `python3 -m unittest tests.test_marker_smoothing_savgol`.
- Risks / Notes
  - The new smoothing option is numerically validated, but the Advanced dialog still needs visual confirmation in the target GUI environment because PySide6 runtime validation was not available here.

한국어
- 요약
  - Marker smoothing 옵션에 Savitzky-Golay를 추가하고, Advanced marker smoothing UI가 선택된 method에 필요한 파라미터만 보이도록 수정했습니다.
- 변경 사항
  - marker smoother에 `savitzky_golay` method를 추가하고 window length, polynomial order 설정을 지원하도록 했습니다.
  - 분석 설정에 Savitzky-Golay 기본값과 라벨을 추가했습니다.
  - Advanced Processing Settings dialog에서 선택한 method sequence에 따라 Butterworth, Moving Average, Savitzky-Golay 파라미터 그룹만 표시되도록 수정했습니다.
  - resampling이 sample-based smoothing 옵션을 보정할 때 Savitzky-Golay window length도 함께 보정되도록 했습니다.
  - 분석 시스템 설계 문서에 Advanced marker smoothing 동작을 반영했습니다.
  - synthetic impact-like 데이터에서 Savitzky-Golay 경로와 low-cutoff Butterworth 대비 피크 간격 보존 경향을 확인하는 수치 회귀 테스트를 추가했습니다.
- 테스트
  - `python -m py_compile src/config/config_analysis.py src/config/config_analysis_ui.py src/analysis/pipeline/smoother.py src/analysis/pipeline/resampling_options.py src/analysis/ui/dialog_processing_settings.py`를 실행했습니다.
  - 수치 검증을 위해 Ubuntu 패키지로 `pandas`, `scipy`를 설치했습니다.
  - `python3 -m unittest tests.test_marker_smoothing_savgol`를 실행했습니다.
- 리스크 / 참고사항
  - 새 smoothing option은 수치적으로 검증했지만, Advanced dialog의 실제 시각적 확인은 이 환경에서 PySide6 런타임 검증이 불가능해 타깃 GUI 환경에서 추가 확인이 필요합니다.