### PR TITLE
Fix Step 1 vertical splitter resizing

### DIFF
--- a/src/analysis/ui/widget_raw_data_processing.py
+++ b/src/analysis/ui/widget_raw_data_processing.py
@@ -115,7 +115,8 @@ class WidgetRawDataProcessing(QWidget):
         # 1b. Bottom Controls
         controls_widget = QWidget()
         h_controls_layout = QHBoxLayout(controls_widget)
-        controls_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Maximum)
+        controls_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+        controls_widget.setMinimumHeight(180)
 
         # Plot Options
         plot_options_group = QGroupBox("Plot Options")


### PR DESCRIPTION
English
- Summary
  - Fix the Step 1 vertical splitter so the lower control panel can actually be resized by the user.
- Changes
  - Change the Step 1 bottom controls widget vertical size policy from `Maximum` to `Preferred`.
  - Add a minimum height so the lower controls do not collapse too aggressively.
- Testing
  - Ran `python -m py_compile src/analysis/ui/widget_raw_data_processing.py`.
- Risks / Notes
  - This is a small layout policy fix. The remaining validation is visual confirmation in the real GUI environment.

한국어
- 요약
  - Step 1 세로 splitter가 실제로 하단 컨트롤 패널 크기를 조절할 수 있도록 수정했습니다.
- 변경 사항
  - Step 1 하단 controls widget의 세로 size policy를 `Maximum`에서 `Preferred`로 변경했습니다.
  - 하단 컨트롤이 지나치게 눌리지 않도록 minimum height를 추가했습니다.
- 테스트
  - `python -m py_compile src/analysis/ui/widget_raw_data_processing.py`를 실행했습니다.
- 리스크 / 참고사항
  - 작은 레이아웃 정책 수정이며, 남은 검증은 실제 GUI 환경에서의 시각적 확인입니다.