### PR TITLE
Fix Results Analyzer column identifier normalization

### DIFF
--- a/src/analysis/ui/widget_results_analyzer.py
+++ b/src/analysis/ui/widget_results_analyzer.py
@@ -26,6 +26,7 @@ from src.config.data_columns import (
     CORNER_NAME_MAP,
     get_result_column_display_path,
     get_result_metric_display_name,
+    normalize_result_column,
 )
 
 class WidgetResultsAnalyzer(QWidget):
@@ -567,7 +568,7 @@ class WidgetResultsAnalyzer(QWidget):
                 column_tuple = leaf_item.data(0, Qt.ItemDataRole.UserRole)
                 if column_tuple is None:
                     column_tuple = (top_item.text(0), mid_item.text(0), leaf_item.text(0))
-                checked_columns.append(column_tuple)
+                checked_columns.append(normalize_result_column(column_tuple))
         return checked_columns
 
     def on_tree_item_changed(self, _item, _column):
@@ -670,9 +671,7 @@ class WidgetResultsAnalyzer(QWidget):
         target_column = self.find_max_target_combo.currentData()
         if target_column is None:
             return None
-
-        if isinstance(target_column, list):
-            target_column = tuple(target_column)
+        target_column = normalize_result_column(target_column)
 
         try:
             value = self.result_data.iloc[selected_index][target_column]
@@ -777,9 +776,7 @@ class WidgetResultsAnalyzer(QWidget):
         if target_column is None:
             self.log_message.emit("[WARNING] No target data selected for peak search.")
             return
-
-        if isinstance(target_column, list):
-            target_column = tuple(target_column)
+        target_column = normalize_result_column(target_column)
 
         try:
             series = pd.to_numeric(self.result_data[target_column], errors='coerce')

--- a/src/config/data_columns.py
+++ b/src/config/data_columns.py
@@ -518,7 +518,21 @@ def get_result_metric_display_name(l1: str, l2: str, l3: str) -> str:
 
 
 def get_result_column_display_path(column: tuple[str, str, str]) -> str:
-    l1, l2, l3 = column
+    l1, l2, l3 = normalize_result_column(column)
     l1_label = RESULT_LEVEL1_DISPLAY.get(l1, str(l1))
     l3_label = get_result_metric_display_name(l1, l2, l3)
     return f"{l1_label} / {l2} / {l3_label}"
+
+
+def normalize_result_column(column: tuple[str, str, str] | list[str]) -> tuple[str, str, str]:
+    if isinstance(column, tuple):
+        normalized = column
+    elif isinstance(column, list):
+        normalized = tuple(column)
+    else:
+        raise TypeError(f"Unsupported result column type: {type(column).__name__}")
+
+    if len(normalized) != 3:
+        raise ValueError(f"Result column must have exactly 3 elements: {normalized!r}")
+
+    return tuple(str(part) for part in normalized)

--- a/tests/test_result_format_layout.py
+++ b/tests/test_result_format_layout.py
@@ -1,5 +1,6 @@
 import unittest
 
+from src.analysis.pipeline.data_loader import DataLoader
 from src.config.data_columns import (
     DISPLAY_RESULT_COLUMNS,
     HeaderL1,
@@ -7,6 +8,7 @@ from src.config.data_columns import (
     HeaderL3,
     get_result_column_display_path,
     get_result_metric_display_name,
+    normalize_result_column,
 )
 
 
@@ -84,6 +86,28 @@ class TestResultFormatLayout(unittest.TestCase):
             get_result_column_display_path((HeaderL1.ACC, "C3", HeaderL3.A_TNORM)),
             "Acceleration / C3 / Acceleration Norm (Global Frame)",
         )
+
+    def test_result_column_normalization_accepts_qt_style_lists(self):
+        self.assertEqual(
+            normalize_result_column([HeaderL1.VEL, HeaderL2.COM, HeaderL3.V_TX]),
+            (HeaderL1.VEL, HeaderL2.COM, HeaderL3.V_TX),
+        )
+        with self.assertRaises(ValueError):
+            normalize_result_column([HeaderL1.VEL, HeaderL2.COM])
+
+    def test_real_result_csv_columns_stay_hashable_after_normalization(self):
+        loader = DataLoader()
+        df = loader.load_result_csv("data/test_real_data_result.csv")
+        matched_columns = [col for col in df.columns if col in DISPLAY_RESULT_COLUMNS]
+
+        self.assertTrue(matched_columns)
+
+        qt_style_columns = [list(col) for col in matched_columns[:5]]
+        normalized_columns = [normalize_result_column(col) for col in qt_style_columns]
+
+        self.assertEqual(len(set(normalized_columns)), len(normalized_columns))
+        selected_df = df[normalized_columns].copy()
+        self.assertFalse(selected_df.empty)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- normalize Results Analyzer column identifiers to hashable `(L1, L2, L3)` tuples
- handle Qt-style list payloads consistently when reading item data and target selections
- add regression coverage using a real exported result CSV for the selection flow

## Summary (Korean)
- Results Analyzer 내부 결과 컬럼 식별자를 hashable `(L1, L2, L3)` tuple로 정규화
- item data와 target selection에서 Qt 스타일 list가 와도 일관되게 처리
- 실제 export 결과 CSV를 사용한 selection flow 회귀 테스트 추가

## Context
- PR #53 updated Results Analyzer display labels to show user-facing metric names
- during follow-up testing, the Step 2 selection flow raised `unhashable type: 'list'`
- this fix keeps the user-facing labels while restoring stable internal column identifiers

## Context (Korean)
- PR #53에서 Results Analyzer 표시명을 사용자 친화적으로 바꾼 뒤
- 후속 테스트 중 Step 2 선택 흐름에서 `unhashable type: 'list'` 에러가 발생함
- 이번 수정은 사용자용 표시명은 유지하면서, 내부 컬럼 식별자를 안정적인 tuple로 복구함

## Testing
- python -m py_compile src/config/data_columns.py src/analysis/ui/widget_results_analyzer.py tests/test_result_format_layout.py
- python -m unittest tests.test_result_format_layout