### PR TITLE
Improve visualization multi-window workflow and viewing controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository AGENTS Guide
 
-Last Reviewed: 2026-03-19
+Last Reviewed: 2026-03-25
 
 이 문서는 저장소 전체에 공통으로 적용하는 작업 원칙을 정리한다.
 
@@ -31,6 +31,11 @@ Last Reviewed: 2026-03-19
 - 후속 개발을 다시 시작할 때는 `docs/analysis/design/analysis_followup_plan.md`를 먼저 확인한다.
 - `PySide6` GUI를 실제로 실행해 검증해야 하는 세션이라면, 임시 handoff 문서인 `docs/analysis/design/gui_validation_plan.md`를 먼저 확인한다.
 - `docs/analysis/design/gui_validation_plan.md`는 장기 기준 문서가 아니라 GUI 검증용 임시 작업 문서이므로, 검증 작업이 끝나고 더 이상 handoff가 필요 없으면 정리 대상이 될 수 있다.
+
+## 현재 Visualization GUI 검증 기준 문서
+- visualization 관련 실제 GUI 검증이 필요한 세션이라면 먼저 `docs/visualization/design/gui_validation_plan.md`를 확인한다.
+- 이 문서는 특히 다중 visualization 창, box edge overlay, projection action 같은 최근 visualization 변경의 실제 화면 검증을 다른 AGENT에게 넘기기 위한 handoff 문서다.
+- `docs/visualization/design/gui_validation_plan.md`도 임시 GUI 검증용 문서이므로, 검증 작업이 끝나고 더 이상 handoff가 필요 없으면 정리 대상이 될 수 있다.
 
 ## 코드 작업 원칙
 - 현재 구현과 맞지 않는 구 버전 스크립트, 테스트, 문서는 유지 이유가 없으면 정리 대상이 될 수 있다.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Box Motion Analyzer
 
-Last Reviewed: 2026-03-19
+Last Reviewed: 2026-03-25
 
 **Box Motion Analyzer**는 모션 캡처 데이터(CSV)를 기반으로 박스와 마커의 움직임을 정밀하게 분석하고, 이를 3D 환경에서 시각화하는 통합 GUI 애플리케이션입니다.
 
@@ -17,6 +17,7 @@ Last Reviewed: 2026-03-19
 *   **인터랙티브 제어:** 재생/일시정지, 프레임 슬라이더 이동, 시점 제어 등이 가능합니다.
 *   **데이터 플로팅:** 선택한 객체의 위치, 속도, 가속도, velocity norm 시계열을 2D 그래프로 확인하고 비교할 수 있습니다.
 *   **심층 분석:** 프레임 구간 필터와 상세 플롯 팝업을 제공하며, 팝업에서는 마우스 오버로 정확한 수치를 확인할 수 있습니다.
+*   **다중 창 비교:** 런처에서 3D Visualization 버튼을 다시 누르거나 시각화 창의 `File > New Visualization Window`를 사용해 독립적인 viewer 창을 여러 개 열 수 있습니다.
 
 ---
 
@@ -84,6 +85,8 @@ python src/main.py
 
 *   **Data Processing**: 원본 CSV를 불러와 분석하고 결과를 `.proc` 중심 workflow로 저장
 *   **3D Visualization**: export된 `.proc` 결과 파일을 열어 3D/2D로 탐색
+    *   런처 버튼을 반복 클릭하면 새 시각화 창이 추가로 열립니다.
+    *   시각화 창 안에서는 `File > New Visualization Window`로 새 창을 바로 만들 수 있습니다.
 
 ### 3. 분석 결과 export와 visualization의 관계
 

--- a/docs/visualization/design/gui_validation_plan.md
+++ b/docs/visualization/design/gui_validation_plan.md
@@ -1,0 +1,235 @@
+# Visualization GUI Validation Plan
+
+Last Reviewed: 2026-03-25
+
+## 목적
+이 문서는 `Codex CLI Agent`가 현재 환경에서 직접 완료하지 못한 3D visualization GUI 검증 항목을
+다른 GUI 실행 가능 AGENT에게 넘기기 위한 handoff 문서다.
+
+현재 `Codex CLI Agent`는 코드 수정, 문서 수정, headless/offscreen 단위 테스트까지는 수행했지만,
+실제 화면에서의 시각 품질과 상호작용은 판정하지 못했다.
+이 문서는 그 차이를 메우기 위해, 실제 GUI를 실행할 수 있는 AGENT
+예를 들어 Google Jules 같은 도구가 어떤 항목을 확인해야 하는지 정리한다.
+
+이 문서의 범위는 아래를 포함한다.
+- Launcher에서의 다중 visualization 창 열기
+- visualization 창 내부의 `File -> New Visualization Window`
+- 여러 visualization 창의 독립 동작
+- box edge overlay의 실제 가시성
+- `Box Edges` 토글의 실제 렌더링 반응
+- `Perspective Projection (Alt+5)` / `Parallel Projection (Alt+6)`의 실제 화면 차이
+- projection shortcut과 메뉴 동작의 실제 사용성
+- 다중 창 + VTK/OpenGL 자원 정리 안정성
+
+## 현재 환경에서 이미 확인한 것
+`Codex CLI Agent`가 현재 환경에서 확인한 범위는 아래다.
+
+- 코드 레벨에서 launcher가 기존 visualization 창을 닫지 않고 새 `MainWindow`를 열도록 변경했다.
+- visualization 창 내부 `File -> New Visualization Window` 액션을 추가했다.
+- box surface와 edge overlay를 내부 helper로 묶어 관리하도록 정리했다.
+- `Display Options`에 `Box Edges` 토글을 추가했다.
+- `View` 메뉴에 아래 projection action을 추가했다.
+  - `Perspective Projection (Alt+5)`
+  - `Parallel Projection (Alt+6)`
+- 아래 headless/offscreen 테스트는 통과했다.
+
+```bash
+env QT_QPA_PLATFORM=offscreen python -m unittest tests.test_launch_headless tests.test_visualization_proc_support
+```
+
+다만 위 테스트는 GUI wiring과 최소 회귀만 확인한 것이고,
+실제 화면에서 보이는 결과나 데스크톱 상호작용은 보장하지 않는다.
+
+## 현재 환경에서 확인하지 못한 것
+아래 항목은 현재 CLI 환경에서 아직 판정하지 못했다.
+
+### 1. 실제 렌더링 품질
+- box edge overlay가 실제로 충분히 진하게 보이는지
+- lightblue surface 위에서 dark gray edge가 기대한 대비를 만드는지
+- 배경색과 시점에 따라 edge가 흐리거나 aliasing으로 깨져 보이지 않는지
+
+### 2. 토글의 실제 시각 반응
+- `Box Edges` 체크박스를 껐을 때 edge만 사라지고 box surface는 남는지
+- 다시 켰을 때 즉시 edge가 복구되는지
+- box 자체를 껐을 때 edges와의 조합이 사용성 측면에서 자연스러운지
+
+### 3. projection 전환의 실제 차이
+- `Alt+5`와 `Alt+6`이 실제로 perspective / parallel projection을 명확히 바꾸는지
+- 메뉴 체크 상태가 실제 projection 상태와 일치하는지
+- projection 전환 직후 장면이 깨지거나 카메라가 비정상적으로 튀지 않는지
+
+### 4. 다중 창 실사용성
+- launcher에서 3D Visualization 버튼을 여러 번 눌렀을 때 창이 독립적으로 열리는지
+- 한 창에서 `.proc` 파일을 열고 다른 창에서는 다른 `.proc` 파일을 열어도 상태가 섞이지 않는지
+- 한 창을 닫아도 다른 창이 영향을 받지 않는지
+- `File -> New Visualization Window`로 연 창도 launcher에서 연 창과 동일한 기능을 갖는지
+
+### 5. 실제 데스크톱 환경 단축키 충돌
+- `Alt+5`, `Alt+6`이 실제 실행 환경의 OS/IME/window manager와 충돌하지 않는지
+- 메뉴 바 포커스와 shortcut 처리 순서 때문에 의도대로 동작하지 않는 경우가 없는지
+
+### 6. OpenGL / VTK 안정성
+- visualization 창을 여러 개 연 뒤 닫는 과정에서 크래시가 없는지
+- projection 전환, 파일 재로드, 창 닫기 조합에서 OpenGL context 관련 오류가 없는지
+- GPU/메모리 사용량이 비정상적으로 증가하지 않는지
+
+## 검증 원칙
+- 가능하면 실제 데스크톱 GUI 환경에서 실행한다.
+- 가능하면 Windows에서 1차 확인하고, 가능하다면 Linux에서도 재확인한다.
+- 검증 AGENT는 기본적으로 코드 수정 없이 재현, 관찰, 기록에 집중한다.
+- 문제를 발견하면 바로 수정하지 말고 재현 절차와 증거를 먼저 남긴다.
+- 각 항목은 `Pass / Fail / Blocked` 중 하나로 판정한다.
+
+## 사전 준비
+- 작업 경로: `/root/BoxMotionAnalyzer`
+- 권장 브랜치: `feat/multi-visualization-windows`
+- 권장 실행 명령:
+
+```bash
+python src/main.py
+```
+
+- visualization 입력 파일:
+  - `.proc` 결과 파일 2개 이상 준비
+  - 가능하면 형태가 약간 다른 결과 파일을 준비해 창 간 비교를 쉽게 한다
+
+## 권장 산출물
+- 실행 환경 정보 메모
+- 창별 스크린샷
+- box edges on/off 비교 스크린샷
+- perspective/parallel projection 비교 스크린샷
+- 다중 창에서 서로 다른 `.proc` 파일을 연 상태의 스크린샷
+- 이상 동작이 있으면 재현 절차와 짧은 영상 또는 연속 스크린샷
+
+## 검증 시나리오
+
+### 1. Launcher에서 다중 창 열기
+- 앱을 실행한다.
+- launcher에서 `3D Visualization` 버튼을 3번 누른다.
+- visualization 창이 3개 열리는지 확인한다.
+- 각 창이 독립 top-level window인지 확인한다.
+
+기대 결과:
+- 기존 창이 닫히지 않는다.
+- 새 창이 계속 추가된다.
+- 창 제목이 파일명 또는 `Window N` 형태로 구분된다.
+
+### 2. File 메뉴에서 새 창 열기
+- visualization 창 하나를 연다.
+- `File -> New Visualization Window`를 실행한다.
+- 새로 열린 창이 launcher에서 열리는 창과 같은 기능을 가지는지 확인한다.
+
+기대 결과:
+- 보조 팝업이 아니라 전체 visualization 메인 창이 열린다.
+- 새 창에서도 `.proc` 파일 열기, 재생, plot, inspector 기능이 모두 가능하다.
+
+### 3. 서로 다른 결과 파일 독립 로드
+- 창 A에는 `.proc` 파일 1을 연다.
+- 창 B에는 `.proc` 파일 2를 연다.
+- 각 창에서 frame 이동, 재생, object selection을 다르게 설정한다.
+
+기대 결과:
+- 현재 프레임, 선택 객체, plot, info log 상태가 창별로 완전히 독립이다.
+- 한 창의 조작이 다른 창의 상태를 바꾸지 않는다.
+
+### 4. Box Edges 가시성
+- box가 잘 보이는 프레임을 잡는다.
+- `Box Edges`가 켜진 상태의 화면을 기록한다.
+- `Box Edges`를 끄고 같은 프레임을 기록한다.
+- 다시 켠다.
+
+기대 결과:
+- edge on 상태에서 box 윤곽이 surface-only 상태보다 명확하다.
+- edge off 상태에서 surface만 남는다.
+- 토글 시 반응이 즉시 보인다.
+
+### 5. Box / Box Edges 조합 동작
+- `Box`만 끈다.
+- `Box Edges`만 끈다.
+- 둘 다 끄거나 켜는 조합을 확인한다.
+
+기대 결과:
+- 최소한 사용자가 이해하기 어려운 깨진 상태가 없어야 한다.
+- 조합이 혼란스럽다면 그 자체를 UX finding으로 기록한다.
+
+### 6. Projection action과 단축키
+- `Alt+5`를 눌러 perspective projection으로 전환한다.
+- `Alt+6`을 눌러 parallel projection으로 전환한다.
+- 메뉴 체크 상태와 실제 projection 상태를 비교한다.
+- `View XY / XZ / YZ / Isometric`과 projection action을 섞어 사용해 본다.
+
+기대 결과:
+- `Alt+5`는 perspective projection으로 고정 진입한다.
+- `Alt+6`은 parallel projection으로 고정 진입한다.
+- 메뉴 체크 상태가 실제 상태와 일치한다.
+- projection 전환 후 다른 view preset도 정상 동작한다.
+
+### 7. 실제 데스크톱 shortcut 충돌
+- launcher와 visualization 창이 포커스를 가진 상태에서 각각 `Alt+5`, `Alt+6`을 눌러본다.
+- 메뉴 바 활성화, IME, OS shortcut과의 충돌 여부를 확인한다.
+
+기대 결과:
+- 의도하지 않은 다른 동작이 발생하지 않는다.
+- shortcut이 안정적으로 먹지 않으면 그 환경과 재현 절차를 기록한다.
+
+### 8. 창 종료와 자원 정리
+- visualization 창을 3개 이상 연다.
+- 파일을 연 상태에서 순서대로 창을 닫는다.
+- projection 전환과 edge 토글을 여러 번 반복한 뒤 창을 닫는다.
+
+기대 결과:
+- 크래시가 없다.
+- 닫히는 과정에서 눈에 띄는 OpenGL/VTK 오류가 없다.
+- 남은 창은 계속 정상 동작한다.
+
+## 증빙 방식
+각 시나리오마다 아래를 남긴다.
+- 실행 날짜/환경
+- 사용한 입력 파일 경로
+- Pass / Fail / Blocked 판정
+- 스크린샷 또는 영상 경로
+- 실패 시 재현 절차
+- 가능하면 관찰한 실제 화면 차이에 대한 짧은 코멘트
+
+## 보고 형식
+검증 AGENT는 결과를 아래 형식으로 정리한다.
+
+```text
+Visualization GUI Validation Report
+
+Environment
+- OS
+- Python version
+- GPU / graphics backend if available
+- Launch command
+
+Results
+- Launcher multi-window: Pass/Fail/Blocked
+- File > New Visualization Window: Pass/Fail/Blocked
+- Independent multi-window state: Pass/Fail/Blocked
+- Box edge visibility: Pass/Fail/Blocked
+- Box / Box Edges toggle behavior: Pass/Fail/Blocked
+- Perspective / Parallel projection actions: Pass/Fail/Blocked
+- Projection shortcut conflicts: Pass/Fail/Blocked
+- Window close / cleanup stability: Pass/Fail/Blocked
+
+Findings
+- ID
+- Severity
+- Repro steps
+- Expected
+- Actual
+- Evidence
+```
+
+## 다른 AGENT에게 바로 전달할 프롬프트
+아래 프롬프트를 그대로 넘겨도 된다.
+
+```text
+Work in /root/BoxMotionAnalyzer on branch feat/multi-visualization-windows.
+Read docs/visualization/design/gui_validation_plan.md first and execute the GUI validation exactly as written.
+Assume Codex CLI Agent already completed code changes and offscreen test coverage, but could not visually validate the GUI.
+Do not change code during the validation pass unless explicitly asked.
+Focus on reproducing behavior, capturing evidence, and reporting findings with exact file paths and concrete steps.
+If the environment blocks GUI execution, report the blocker clearly and stop at that point.
+```

--- a/docs/visualization/guide.md
+++ b/docs/visualization/guide.md
@@ -63,6 +63,7 @@ Last Reviewed: 2026-03-25
 - 1차 구현에서는 서로 다른 entity type의 동시 선택을 제한한다.
 - `PlotWidget` 더블클릭 시 `PlotDialog`가 열려 확대 플롯을 볼 수 있다.
 - frame range 체크박스와 spinbox로 선택 구간만 플롯할 수 있다.
+- `View -> Perspective Projection (Alt+5)`와 `View -> Parallel Projection (Alt+6)`로 투영 방식을 명시적으로 전환할 수 있다.
 
 ## 7. 참고할 구현 포인트
 - 결과 파일 헤더 규칙이 바뀌면 다음을 함께 확인해야 한다.

--- a/docs/visualization/guide.md
+++ b/docs/visualization/guide.md
@@ -1,6 +1,6 @@
 # Visualization Guide
 
-Last Reviewed: 2026-03-19
+Last Reviewed: 2026-03-25
 
 이 문서는 `src/visualization/` 아래 3D 시각화 기능이 어떤 구조로 동작하는지 설명한다.
 
@@ -11,6 +11,8 @@ Last Reviewed: 2026-03-19
 ## 2. 진입점
 - 전체 앱 진입점: `src/main.py`
 - 시각화 창 진입점: `src/launcher.py` -> `LauncherWindow` -> `src.visualization.main_window.MainWindow`
+- 런처에서 `3D Visualization` 버튼을 다시 누르면 독립적인 시각화 창이 추가로 열린다.
+- 시각화 창 내부에서도 `File -> New Visualization Window`로 같은 종류의 새 메인 창을 열 수 있다.
 
 ## 3. 현재 구조
 - `src/visualization/main_window.py`
@@ -48,6 +50,7 @@ Last Reviewed: 2026-03-19
 - visualization은 분석 결과 파일을 직접 읽는다. 원본 raw CSV를 바로 읽는 흐름이 아니다.
 - `DataHandler`는 결과 파일의 `Position`, `Velocity`, `Acceleration`, `Info` multi-header를 해석한다.
 - UI에서는 `.proc`만 노출해 raw `.csv`와의 혼동을 줄인다.
+- 각 시각화 창은 독립적으로 결과 파일을 열고 재생 상태를 유지한다.
 - visualization 내부 metric 키도 export 스키마를 그대로 따른다.
   - 예: `P_TX`, `Global_V_TX`, `Global_V_T_Norm`, `BoxLocal_A_T_Norm`
 - `Scene Inspector`는 `Center of Mass / Corners / Markers` 그룹으로 entity를 나눠 보여준다.

--- a/src/config/config_visualization.py
+++ b/src/config/config_visualization.py
@@ -115,6 +115,7 @@ STYLE = {
     "box": {
         "color": "lightblue",
         "opacity": 0.5,
+        "edge_color": "#2f3640",
         "line_width": 2
     },
     "labels": {
@@ -200,6 +201,7 @@ SK_CENTER = 'center'
 SK_SIZE = 'size'
 SK_COLOR = 'color'
 SK_OPACITY = 'opacity'
+SK_EDGE_COLOR = 'edge_color'
 SK_LINE_WIDTH = 'line_width'
 SK_FONT_SIZE_BOX = 'box_font_size'
 SK_FONT_SIZE_MARKER = 'marker_font_size'
@@ -208,6 +210,7 @@ SK_COLOR_MAP = 'color_map'
 
 # For Actor/PolyData dictionaries and face definitions
 SK_ACTOR_BOX = 'box'
+SK_ACTOR_BOX_EDGES = 'box_edges'
 SK_ACTOR_MARKERS = 'markers'
 SK_ACTOR_LABELS = 'labels'
 SK_FACE_LABEL = 'label'

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -23,7 +23,6 @@ class LauncherWindow(QMainWindow):
         self.setWindowIcon(get_window_icon())
         self.resize(840, 380)
 
-        self.main_window = None
         self.data_processing_window = None
 
         # --- Main Layout ---
@@ -67,6 +66,15 @@ class LauncherWindow(QMainWindow):
         self.btn_visualization.setFixedSize(320, 50)
         right_panel_layout.addWidget(self.btn_visualization, 0, Qt.AlignHCenter)
 
+        self.visualization_hint_label = QLabel(
+            "Click again to open another independent 3D visualization window."
+        )
+        self.visualization_hint_label.setWordWrap(True)
+        self.visualization_hint_label.setAlignment(Qt.AlignCenter)
+        self.visualization_hint_label.setFixedWidth(320)
+        self.visualization_hint_label.setStyleSheet("color: #4a5568;")
+        right_panel_layout.addWidget(self.visualization_hint_label, 0, Qt.AlignHCenter)
+
         right_panel_layout.addStretch(1)
 
         main_layout.addWidget(right_panel, 0, Qt.AlignVCenter)
@@ -74,12 +82,7 @@ class LauncherWindow(QMainWindow):
 
     def open_visualization(self):
         """Opens the main 3D visualization window."""
-        # Ensure any existing window is closed and a fresh instance is created
-        if self.main_window is not None:
-            self.main_window.close()
-
-        self.main_window = MainWindow()
-        self.main_window.show()
+        MainWindow.create_and_show()
 
     def open_data_processing(self):
         """Opens the data processing window (MainApp)."""

--- a/src/visualization/control_panel.py
+++ b/src/visualization/control_panel.py
@@ -48,6 +48,12 @@ class ControlPanel(QWidget):
             lambda checked: self.visibility_changed.emit(config.SK_ACTOR_BOX, checked)
         )
 
+        self.box_edges_checkbox = QCheckBox("Box Edges")
+        self.box_edges_checkbox.setChecked(True)
+        self.box_edges_checkbox.toggled.connect(
+            lambda checked: self.visibility_changed.emit(config.SK_ACTOR_BOX_EDGES, checked)
+        )
+
         self.markers_checkbox = QCheckBox("Markers")
         self.markers_checkbox.setChecked(True)
         self.markers_checkbox.toggled.connect(
@@ -61,6 +67,7 @@ class ControlPanel(QWidget):
         )
 
         layout.addWidget(self.box_checkbox)
+        layout.addWidget(self.box_edges_checkbox)
         layout.addWidget(self.markers_checkbox)
         layout.addWidget(self.labels_checkbox)
         layout.addStretch()

--- a/src/visualization/main_window.py
+++ b/src/visualization/main_window.py
@@ -142,6 +142,20 @@ class MainWindow(QMainWindow):
         view_iso_action.triggered.connect(self.vista_widget.view_isometric)
         view_menu.addAction(view_iso_action)
 
+        view_menu.addSeparator()
+
+        self.perspective_projection_action = QAction("&Perspective Projection (Alt+5)", self)
+        self.perspective_projection_action.setShortcut("Alt+5")
+        self.perspective_projection_action.triggered.connect(self.enable_perspective_projection)
+        view_menu.addAction(self.perspective_projection_action)
+
+        self.parallel_projection_action = QAction("&Parallel Projection (Alt+6)", self)
+        self.parallel_projection_action.setShortcut("Alt+6")
+        self.parallel_projection_action.triggered.connect(self.enable_parallel_projection)
+        view_menu.addAction(self.parallel_projection_action)
+
+        self._sync_projection_actions()
+
     def open_result_file(self):
         filepath, _ = QFileDialog.getOpenFileName(self, "Open Result File", "", result_file_filter())
         if filepath:
@@ -198,6 +212,23 @@ class MainWindow(QMainWindow):
     def open_new_visualization_window(self):
         offset_position = (self.x() + 40, self.y() + 40)
         self.create_and_show(position_hint=offset_position)
+
+    def _sync_projection_actions(self):
+        is_parallel = self.vista_widget.is_parallel_projection_enabled()
+        self.perspective_projection_action.setCheckable(True)
+        self.parallel_projection_action.setCheckable(True)
+        self.perspective_projection_action.setChecked(not is_parallel)
+        self.parallel_projection_action.setChecked(is_parallel)
+
+    def enable_perspective_projection(self):
+        self.vista_widget.set_parallel_projection(False)
+        self._sync_projection_actions()
+        self.statusBar().showMessage("Perspective projection enabled.", 3000)
+
+    def enable_parallel_projection(self):
+        self.vista_widget.set_parallel_projection(True)
+        self._sync_projection_actions()
+        self.statusBar().showMessage("Parallel projection enabled.", 3000)
 
     def set_frame(self, frame_number: int):
         self.current_frame = frame_number

--- a/src/visualization/main_window.py
+++ b/src/visualization/main_window.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from PySide6.QtWidgets import (
     QMainWindow, QVBoxLayout, QHBoxLayout, QWidget, QFileDialog, QApplication
@@ -17,14 +18,21 @@ from .info_log_widget import InfoLogWidget
 from src.utils.app_identity import configure_qt_application, get_window_icon
 
 class MainWindow(QMainWindow):
+    open_windows = []
+    _window_sequence = 0
+
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("3D Motion Analyzer")
         self.setWindowIcon(get_window_icon())
         self.setGeometry(100, 100, 1800, 1000)
+        self.setAttribute(Qt.WA_DeleteOnClose, True)
 
         self.current_frame = 0
+        self.loaded_result_path = None
         self.plot_dialogs = []
+        self.window_sequence = self._next_window_sequence()
+
+        self._update_window_title()
 
         # 1. Create core components
         self.data_handler = DataHandler()
@@ -91,6 +99,11 @@ class MainWindow(QMainWindow):
 
         # File Menu
         file_menu = menu_bar.addMenu("&File")
+        new_window_action = QAction("&New Visualization Window", self)
+        new_window_action.setShortcut("Ctrl+N")
+        new_window_action.triggered.connect(self.open_new_visualization_window)
+        file_menu.addAction(new_window_action)
+        file_menu.addSeparator()
         open_action = QAction("&Open Result File...", self)
         open_action.triggered.connect(self.open_result_file)
         file_menu.addAction(open_action)
@@ -135,6 +148,8 @@ class MainWindow(QMainWindow):
             self.statusBar().showMessage(f"Loading {filepath}...")
             success = self.data_handler.load_analysis_result(filepath)
             if success:
+                self.loaded_result_path = filepath
+                self._update_window_title()
                 self.animation_widget.set_frame_range(self.data_handler.n_frames)
                 self.control_panel.populate_scene_inspector(self.data_handler.get_entities_by_type())
 
@@ -154,6 +169,35 @@ class MainWindow(QMainWindow):
 
     def open_csv_file(self):
         self.open_result_file()
+
+    @classmethod
+    def _next_window_sequence(cls):
+        cls._window_sequence += 1
+        return cls._window_sequence
+
+    @classmethod
+    def create_and_show(cls, *, position_hint=None):
+        window = cls()
+        cls.open_windows.append(window)
+        window.destroyed.connect(
+            lambda *_: cls.open_windows.remove(window) if window in cls.open_windows else None
+        )
+        if position_hint is not None:
+            window.move(*position_hint)
+        window.show()
+        return window
+
+    def _update_window_title(self):
+        base_title = "3D Motion Analyzer"
+        if self.loaded_result_path:
+            self.setWindowTitle(f"{base_title} - {os.path.basename(self.loaded_result_path)}")
+            return
+
+        self.setWindowTitle(f"{base_title} - Window {self.window_sequence}")
+
+    def open_new_visualization_window(self):
+        offset_position = (self.x() + 40, self.y() + 40)
+        self.create_and_show(position_hint=offset_position)
 
     def set_frame(self, frame_number: int):
         self.current_frame = frame_number

--- a/src/visualization/vista_widget.py
+++ b/src/visualization/vista_widget.py
@@ -22,11 +22,58 @@ class VistaWidget(QWidget):
 
         # --- Centralized Actor and PolyData Management ---
         k = config
-        self.actors = {k.SK_ACTOR_BOX: None, k.SK_ACTOR_MARKERS: {}, k.SK_ACTOR_LABELS: {}}
+        self.actors = {
+            k.SK_ACTOR_BOX: None,
+            k.SK_ACTOR_BOX_EDGES: None,
+            k.SK_ACTOR_MARKERS: {},
+            k.SK_ACTOR_LABELS: {},
+        }
         self.polydata = {k.SK_ACTOR_BOX: None, k.SK_ACTOR_MARKERS: {}, k.SK_ACTOR_LABELS: {}}
 
         if not testing_mode:
             self._setup_scene()
+
+    def _create_box_visuals(self, box_points):
+        s = config.STYLE
+        k = config
+        faces = np.hstack([([4] + face[k.SK_CORNER_INDICES]) for face in k.BOX_FACES])
+        self.polydata[k.SK_ACTOR_BOX] = pv.PolyData(box_points, faces=faces)
+        self.actors[k.SK_ACTOR_BOX] = self.plotter.add_mesh(
+            self.polydata[k.SK_ACTOR_BOX],
+            style='surface',
+            color=s[k.SK_BOX][k.SK_COLOR],
+            opacity=s[k.SK_BOX][k.SK_OPACITY],
+            name="box",
+        )
+        self.actors[k.SK_ACTOR_BOX_EDGES] = self.plotter.add_mesh(
+            self.polydata[k.SK_ACTOR_BOX],
+            style='wireframe',
+            color=s[k.SK_BOX][k.SK_EDGE_COLOR],
+            line_width=s[k.SK_BOX][k.SK_LINE_WIDTH],
+            name="box_edges",
+        )
+        self.polydata[k.SK_ACTOR_LABELS][k.SK_ACTOR_BOX] = pv.PolyData(box_points)
+        self.actors[k.SK_ACTOR_LABELS][k.SK_ACTOR_BOX] = self.plotter.add_point_labels(
+            self.polydata[k.SK_ACTOR_LABELS][k.SK_ACTOR_BOX],
+            k.BOX_CORNERS_LABELS,
+            name="box_labels",
+            font_size=s[k.SK_LABELS][k.SK_FONT_SIZE_BOX],
+        )
+
+    def _update_box_visuals(self, box_points):
+        k = config
+        if self.actors[k.SK_ACTOR_BOX] is None:
+            self._create_box_visuals(box_points)
+            return
+
+        self.polydata[k.SK_ACTOR_BOX].points = box_points
+        self.polydata[k.SK_ACTOR_BOX].Modified()
+        self._update_polydata_points(self.polydata[k.SK_ACTOR_LABELS], k.SK_ACTOR_BOX, box_points)
+
+    def _set_box_actor_visibility(self, actor_name: str, is_visible: bool):
+        actor = self.actors.get(actor_name)
+        if actor:
+            actor.SetVisibility(is_visible)
 
     def _setup_scene(self):
         """Initial setup of the plotter and permanent actors."""
@@ -85,23 +132,7 @@ class VistaWidget(QWidget):
         # --- Update Box ---
         box_points = self._get_points_for_ids(frame_df, k.BOX_CORNERS_LABELS)
         if box_points is not None:
-            if self.actors[k.SK_ACTOR_BOX] is None:
-                faces = np.hstack([([4] + face[k.SK_CORNER_INDICES]) for face in k.BOX_FACES])
-                self.polydata[k.SK_ACTOR_BOX] = pv.PolyData(box_points, faces=faces)
-                self.actors[k.SK_ACTOR_BOX] = self.plotter.add_mesh(
-                    self.polydata[k.SK_ACTOR_BOX], style='surface',
-                    color=s[k.SK_BOX][k.SK_COLOR], opacity=s[k.SK_BOX][k.SK_OPACITY],
-                    name="box"
-                )
-                self.polydata[k.SK_ACTOR_LABELS][k.SK_ACTOR_BOX] = pv.PolyData(box_points)
-                self.actors[k.SK_ACTOR_LABELS][k.SK_ACTOR_BOX] = self.plotter.add_point_labels(
-                    self.polydata[k.SK_ACTOR_LABELS][k.SK_ACTOR_BOX], k.BOX_CORNERS_LABELS,
-                    name="box_labels", font_size=s[k.SK_LABELS][k.SK_FONT_SIZE_BOX]
-                )
-            else:
-                self.polydata[k.SK_ACTOR_BOX].points = box_points
-                self.polydata[k.SK_ACTOR_BOX].Modified()
-                self._update_polydata_points(self.polydata[k.SK_ACTOR_LABELS], k.SK_ACTOR_BOX, box_points)
+            self._update_box_visuals(box_points)
 
         # --- Update Markers (Dynamic) ---
         # 1. Identify marker entities from the exported visualization data model.
@@ -266,8 +297,8 @@ class VistaWidget(QWidget):
         """Sets the visibility of actors."""
         if self.plotter is None: return
         k = config
-        if actor_name == k.SK_ACTOR_BOX and self.actors[k.SK_ACTOR_BOX]:
-            self.actors[k.SK_ACTOR_BOX].SetVisibility(is_visible)
+        if actor_name in {k.SK_ACTOR_BOX, k.SK_ACTOR_BOX_EDGES}:
+            self._set_box_actor_visibility(actor_name, is_visible)
         elif actor_name == k.SK_ACTOR_MARKERS:
             for actor in self.actors[k.SK_ACTOR_MARKERS].values():
                 actor.SetVisibility(is_visible)

--- a/src/visualization/vista_widget.py
+++ b/src/visualization/vista_widget.py
@@ -188,6 +188,17 @@ class VistaWidget(QWidget):
         if self.plotter:
             self.plotter.reset_camera()
 
+    def is_parallel_projection_enabled(self):
+        if self.plotter is None:
+            return False
+        return bool(self.plotter.camera.GetParallelProjection())
+
+    def set_parallel_projection(self, enabled: bool):
+        if self.plotter is None:
+            return
+        self.plotter.camera.SetParallelProjection(bool(enabled))
+        self.plotter.render()
+
     def view_xy_plane(self):
         """Sets view to XY plane (Looking along Z axis)."""
         if self.plotter:

--- a/tests/test_launch_headless.py
+++ b/tests/test_launch_headless.py
@@ -1,35 +1,45 @@
 import sys
 import os
 import unittest
+import importlib
 from unittest.mock import patch, MagicMock
 
 # Add project root to path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+try:
+    from PySide6.QtWidgets import QApplication
+    from src.launcher import LauncherWindow
+    HAS_QT = True
+except ModuleNotFoundError:
+    QApplication = None
+    LauncherWindow = None
+    HAS_QT = False
+
 class TestHeadlessLaunch(unittest.TestCase):
-    @patch('src.main.LauncherWindow')
-    @patch('src.main.QApplication')
-    def test_main_function(self, MockQApp, MockLauncher):
+    @unittest.skipUnless(HAS_QT, "PySide6 is required for main entrypoint tests.")
+    def test_main_function(self):
         """
         Verifies that src.main.main() initializes QApplication and shows LauncherWindow
         using mocks to avoid actual GUI creation and Segfaults.
         """
         print("\n[Test] Verifying src/main.py logic via Mocks...")
 
-        # Delayed import to ensure patches are active if import triggers anything (it shouldn't)
-        from src.main import main
+        main_module = importlib.import_module("src.main")
 
-        # Setup mocks
-        mock_app_instance = MagicMock()
-        MockQApp.return_value = mock_app_instance
+        with patch.object(main_module, "QApplication") as MockQApp, patch.object(
+            main_module, "LauncherWindow"
+        ) as MockLauncher:
+            mock_app_instance = MagicMock()
+            MockQApp.return_value = mock_app_instance
 
-        mock_window_instance = MagicMock()
-        MockLauncher.return_value = mock_window_instance
+            mock_window_instance = MagicMock()
+            MockLauncher.return_value = mock_window_instance
 
-        # Run main()
-        # It calls sys.exit(app.exec()), so we expect SystemExit
-        with self.assertRaises(SystemExit):
-            main()
+            # Run main()
+            # It calls sys.exit(app.exec()), so we expect SystemExit
+            with self.assertRaises(SystemExit):
+                main_module.main()
 
         print("[Pass] src.main.main() ran to completion (sys.exit).")
 
@@ -46,6 +56,28 @@ class TestHeadlessLaunch(unittest.TestCase):
         # 4. app.exec() should be called
         mock_app_instance.exec.assert_called_once()
         print("[Pass] All main() steps verified: App created, Window shown, Exec called.")
+
+    @classmethod
+    def setUpClass(cls):
+        if HAS_QT:
+            cls.app = QApplication.instance() or QApplication([])
+
+    @unittest.skipUnless(HAS_QT, "PySide6 is required for launcher window tests.")
+    @patch('src.launcher.MainWindow.create_and_show')
+    def test_launcher_can_open_multiple_visualization_windows(self, mock_create_and_show):
+        first_window = MagicMock()
+        second_window = MagicMock()
+        mock_create_and_show.side_effect = [first_window, second_window]
+
+        window = LauncherWindow()
+        try:
+            window.open_visualization()
+            window.open_visualization()
+        finally:
+            window.close()
+
+        self.assertEqual(mock_create_and_show.call_count, 2)
+        first_window.close.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_visualization_proc_support.py
+++ b/tests/test_visualization_proc_support.py
@@ -90,6 +90,9 @@ class TestVisualizationProcSupport(unittest.TestCase):
         finally:
             window.close()
 
+    def test_result_file_filter_prefers_proc_files(self):
+        self.assertEqual(result_file_filter(), "Result Files (*.proc)")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_visualization_proc_support.py
+++ b/tests/test_visualization_proc_support.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pandas as pd
 
@@ -76,6 +76,17 @@ class TestVisualizationProcSupport(unittest.TestCase):
                 window.open_result_file()
 
             mock_dialog.assert_called_once_with(window, "Open Result File", "", result_file_filter())
+        finally:
+            window.close()
+
+    @unittest.skipUnless(HAS_QT, "PySide6 is required for visualization window tests.")
+    def test_main_window_can_request_a_new_visualization_window(self):
+        window = MainWindow()
+        try:
+            with patch.object(MainWindow, "create_and_show", return_value=MagicMock()) as mock_create:
+                window.open_new_visualization_window()
+
+            mock_create.assert_called_once()
         finally:
             window.close()
 

--- a/tests/test_visualization_proc_support.py
+++ b/tests/test_visualization_proc_support.py
@@ -90,6 +90,17 @@ class TestVisualizationProcSupport(unittest.TestCase):
         finally:
             window.close()
 
+    @unittest.skipUnless(HAS_QT, "PySide6 is required for visualization window tests.")
+    def test_main_window_exposes_projection_shortcuts(self):
+        window = MainWindow()
+        try:
+            self.assertTrue(window.perspective_projection_action.isCheckable())
+            self.assertTrue(window.parallel_projection_action.isCheckable())
+            self.assertEqual(window.perspective_projection_action.shortcut().toString(), "Alt+5")
+            self.assertEqual(window.parallel_projection_action.shortcut().toString(), "Alt+6")
+        finally:
+            window.close()
+
     def test_result_file_filter_prefers_proc_files(self):
         self.assertEqual(result_file_filter(), "Result Files (*.proc)")
 


### PR DESCRIPTION
English
- Summary
  Improve the 3D visualization workflow by allowing multiple independent viewer windows, making box outlines easier to read, and adding explicit projection controls.

- Changes
  Add support for opening multiple independent visualization windows from both the launcher and the File menu.
  Add a box edge overlay and a Box Edges display toggle to improve box visibility.
  Add explicit projection actions for Perspective (Alt+5) and Parallel (Alt+6) in the View menu.
  Update visualization docs and add a GUI validation handoff document for follow-up validation in a real desktop environment.

- Testing
  Ran:
  env QT_QPA_PLATFORM=offscreen python -m unittest tests.test_launch_headless tests.test_visualization_proc_support

- Risks / Notes
  The current CLI environment only covered headless/offscreen validation.
  Actual visual quality, shortcut behavior in a desktop session, and multi-window OpenGL/VTK stability still need real GUI validation.
  Follow-up validation guidance is documented in docs/visualization/design/gui_validation_plan.md.

한국어
- 요약
  여러 개의 독립적인 visualization 창을 열 수 있게 하고, 박스 외곽선을 더 잘 보이게 하며, 투영 전환 기능을 명시적으로 추가해 3D visualization 사용 흐름을 개선합니다.

- 변경 사항
  launcher와 File 메뉴 양쪽에서 독립적인 visualization 창을 여러 개 열 수 있도록 지원했습니다.
  박스 가시성을 높이기 위해 box edge overlay와 Box Edges 표시 토글을 추가했습니다.
  View 메뉴에 Perspective (Alt+5), Parallel (Alt+6) 투영 전환 액션을 추가했습니다.
  visualization 문서를 갱신하고, 실제 GUI 환경에서 후속 검증을 넘길 수 있도록 handoff 문서를 추가했습니다.

- 테스트
  실행:
  env QT_QPA_PLATFORM=offscreen python -m unittest tests.test_launch_headless tests.test_visualization_proc_support

- 리스크 / 참고사항
  현재 CLI 환경에서는 headless/offscreen 검증만 수행했습니다.
  실제 화면에서의 시각 품질, 데스크톱 환경에서의 shortcut 동작, 다중 창 OpenGL/VTK 안정성은 추가 GUI 검증이 필요합니다.
  후속 검증 가이드는 docs/visualization/design/gui_validation_plan.md에 정리했습니다.
