### PR TITLE
Improve plot legends, titles, and layout behavior

### DIFF
--- a/src/analysis/ui/plot_manager.py
+++ b/src/analysis/ui/plot_manager.py
@@ -45,7 +45,6 @@ class PlotManager(QObject):
             color = colors[i % len(colors)]
             self.ax.plot(x_data, y_data, color=color, label=label)
 
-        self.ax.set_title(f"Plot for: {', '.join(labels_to_plot)}")
         self.ax.set_xlabel("Time (s)")
         self.ax.set_ylabel("Value")
         self.ax.grid(True)
@@ -53,6 +52,7 @@ class PlotManager(QObject):
             self.ax.legend()
 
         self._initialize_hover_annotation()
+        self.fig.tight_layout()
         self.canvas.draw()
 
     def clear_plot(self):

--- a/src/analysis/ui/plot_manager.py
+++ b/src/analysis/ui/plot_manager.py
@@ -49,7 +49,7 @@ class PlotManager(QObject):
         self.ax.set_xlabel("Time (s)")
         self.ax.set_ylabel("Value")
         self.ax.grid(True)
-        if len(columns_to_plot) > 1:
+        if labels_to_plot:
             self.ax.legend()
 
         self._initialize_hover_annotation()

--- a/src/analysis/ui/plot_popup_dialog.py
+++ b/src/analysis/ui/plot_popup_dialog.py
@@ -45,7 +45,7 @@ class PlotPopupDialog(QDialog):
 
         plot_df = result_data[available_columns].copy()
         self.plot_manager.draw_plot(plot_df, available_columns)
-        self.plot_manager.ax.set_title(f"Popup Plot - {self.window_name}")
+        self.plot_manager.ax.set_title("")
         self.plot_manager.canvas.draw_idle()
 
     def set_selected_time_cursor(self, selected_time):

--- a/src/analysis/ui/widget_raw_data_processing.py
+++ b/src/analysis/ui/widget_raw_data_processing.py
@@ -62,7 +62,6 @@ class WidgetRawDataProcessing(QWidget):
         plot_layout.setContentsMargins(0, 0, 0, 0)
         
         self.fig = Figure(figsize=(5, 4), dpi=100)
-        self.fig.subplots_adjust(left=0.08, right=0.98, bottom=0.1, top=0.95)
         self.canvas = FigureCanvas(self.fig)
         self.toolbar = NavigationToolbar(self.canvas, self)
 

--- a/src/analysis/ui/widget_results_analyzer.py
+++ b/src/analysis/ui/widget_results_analyzer.py
@@ -245,7 +245,6 @@ class WidgetResultsAnalyzer(QWidget):
         main_plot_layout.setSpacing(2)
 
         self.fig = Figure(figsize=(5, 4), dpi=100)
-        self.fig.subplots_adjust(left=0.055, right=0.995, bottom=0.085, top=0.995)
         self.canvas = FigureCanvas(self.fig)
         self.toolbar = NavigationToolbar(self.canvas, self)
         main_plot_layout.addWidget(self.toolbar)

--- a/src/analysis/ui/widget_slice_processing.py
+++ b/src/analysis/ui/widget_slice_processing.py
@@ -72,7 +72,6 @@ class WidgetSliceProcessing(QWidget):
         plot_layout.setContentsMargins(0, 0, 0, 0)
 
         self.fig = Figure(figsize=(5, 4), dpi=100)
-        self.fig.subplots_adjust(left=0.08, right=0.98, bottom=0.1, top=0.95)
         self.canvas = FigureCanvas(self.fig)
         self.toolbar = NavigationToolbar(self.canvas, self)
         plot_layout.addWidget(self.toolbar)

--- a/src/visualization/plot_dialog.py
+++ b/src/visualization/plot_dialog.py
@@ -42,7 +42,7 @@ class PlotDialog(QWidget):
         self.ax.clear()
         for args in plot_args:
             self.ax.plot(args["x"], args["y"], label=args["label"])
-        self.ax.set_title(f"{y_axis_label} Timeseries (Detailed View)")
+        self.ax.set_title("")
         self.ax.set_xlabel("Time (s)")
         self.ax.set_ylabel(y_axis_label)
         if len(plot_args) > 1:

--- a/src/visualization/plot_widget.py
+++ b/src/visualization/plot_widget.py
@@ -27,7 +27,6 @@ class PlotWidget(QWidget):
         frame_layout.addWidget(self.canvas)
 
         self.ax = self.canvas.figure.subplots()
-        self.ax.set_title("Data Plot")
 
         self.canvas.mouseDoubleClickEvent = self.on_double_click
 
@@ -41,7 +40,7 @@ class PlotWidget(QWidget):
         for args in plot_args:
             self.ax.plot(args["x"], args["y"], label=args["label"])
 
-        self.ax.set_title(f"{y_axis_label} Timeseries")
+        self.ax.set_title("")
         self.ax.set_xlabel("Time (s)")
         self.ax.set_ylabel(y_axis_label)
 


### PR DESCRIPTION
English
- Summary
  Improve plot readability and consistency across analysis and visualization views.

- Changes
  Show analysis plot legends even when a single series is selected.
  Remove internal plot titles from visualization plots and analysis popups for a more consistent UI.
  Replace fixed analysis subplot margins with tight layout handling during redraws.

- Testing
  Not run in this environment.

- Risks / Notes
  The analysis plot layout now depends on matplotlib tight_layout() instead of fixed subplot margins.
  Real GUI validation is still useful to confirm legend placement and spacing in different window sizes.

한국어
- 요약
  analysis 및 visualization 화면 전반에서 plot의 가독성과 일관성을 개선합니다.

- 변경 사항
  analysis plot에서 단일 series를 선택한 경우에도 범례가 표시되도록 했습니다.
  UI 일관성을 위해 visualization plot과 analysis popup의 내부 그래프 제목을 제거했습니다.
  analysis plot은 고정 subplot margin 대신 redraw 시 tight_layout()을 사용하도록 변경했습니다.

- 테스트
  이 환경에서는 실행하지 않았습니다.

- 리스크 / 참고사항
  analysis plot 레이아웃은 이제 고정 subplot margin 대신 matplotlib tight_layout() 동작에 의존합니다.
  실제 GUI 환경에서 창 크기에 따른 범례 위치와 여백을 추가 확인하는 것이 좋습니다.