### PR TITLE
Improve plot legends, titles, and layout behavior

### DIFF
--- a/src/visualization/plot_dialog.py
+++ b/src/visualization/plot_dialog.py
@@ -1,9 +1,11 @@
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import QWidget, QVBoxLayout
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT, FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 
 class PlotDialog(QWidget):
+    DEFAULT_Y_AXIS_LABEL = "Value"
+
     def __init__(self, plot_args: list[dict], y_axis_label: str, parent=None):
         super().__init__(parent)
         self.setWindowFlag(Qt.Window, True)
@@ -12,6 +14,7 @@ class PlotDialog(QWidget):
         self.setGeometry(200, 200, 800, 600)
 
         layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
 
         # Create a new FigureCanvas and Axes for the dialog
         self.canvas = FigureCanvas(Figure(figsize=(10, 8)))
@@ -44,12 +47,19 @@ class PlotDialog(QWidget):
             self.ax.plot(args["x"], args["y"], label=args["label"])
         self.ax.set_title("")
         self.ax.set_xlabel("Time (s)")
-        self.ax.set_ylabel(y_axis_label)
-        if len(plot_args) > 1:
+        self.ax.set_ylabel(self.DEFAULT_Y_AXIS_LABEL)
+        if plot_args:
             self.ax.legend()
         self.ax.grid(True)
-        self.canvas.figure.tight_layout()
-        self.canvas.draw()
+        self._refresh_layout()
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        QTimer.singleShot(0, self._refresh_layout)
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._refresh_layout()
 
     def on_motion(self, event):
         """Callback for mouse motion event to show data annotations."""
@@ -88,4 +98,8 @@ class PlotDialog(QWidget):
         else:
             self.annot.set_visible(False)
 
+        self.canvas.draw_idle()
+
+    def _refresh_layout(self):
+        self.canvas.figure.tight_layout()
         self.canvas.draw_idle()

--- a/src/visualization/plot_widget.py
+++ b/src/visualization/plot_widget.py
@@ -5,11 +5,12 @@ from PySide6.QtCore import Signal
 
 class PlotWidget(QWidget):
     doubleClicked = Signal()
+    DEFAULT_Y_AXIS_LABEL = "Value"
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self.current_plot_args = []
-        self.y_axis_label = "Value"
+        self.y_axis_label = self.DEFAULT_Y_AXIS_LABEL
 
         # --- Create a frame to provide a border ---
         frame = QFrame(self)
@@ -23,6 +24,7 @@ class PlotWidget(QWidget):
 
         # Layout for the contents of the frame
         frame_layout = QVBoxLayout(frame)
+        frame_layout.setContentsMargins(0, 0, 0, 0)
         self.canvas = FigureCanvas(Figure(figsize=(5, 3)))
         frame_layout.addWidget(self.canvas)
 
@@ -33,7 +35,7 @@ class PlotWidget(QWidget):
     def plot_multiple_data(self, plot_args: list[dict], y_axis_label: str = "Value"):
         """Plots multiple lines on the same graph and stores the data for the popup."""
         self.current_plot_args = plot_args
-        self.y_axis_label = y_axis_label
+        self.y_axis_label = self.DEFAULT_Y_AXIS_LABEL
 
         self.ax.clear()
 
@@ -42,16 +44,22 @@ class PlotWidget(QWidget):
 
         self.ax.set_title("")
         self.ax.set_xlabel("Time (s)")
-        self.ax.set_ylabel(y_axis_label)
+        self.ax.set_ylabel(self.DEFAULT_Y_AXIS_LABEL)
 
-        # Add a legend only if there are multiple lines to distinguish
-        if len(plot_args) > 1:
+        if plot_args:
             self.ax.legend()
 
         self.ax.grid(True)
-        self.canvas.figure.tight_layout()  # Adjust layout to prevent labels from being cut off
-        self.canvas.draw()
+        self._refresh_layout()
 
     def on_double_click(self, event):
         """Emits a signal when the canvas is double-clicked."""
         self.doubleClicked.emit()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._refresh_layout()
+
+    def _refresh_layout(self):
+        self.canvas.figure.tight_layout()
+        self.canvas.draw_idle()


### PR DESCRIPTION
English
- Summary
  Improve plot readability and consistency across analysis and visualization views.

- Changes
  Show analysis plot legends even when a single series is selected.
  Remove internal plot titles from analysis popups and visualization plots.
  Replace fixed analysis subplot margins with tight layout handling during redraws.
  Align visualization plots to use a consistent Value y-axis label, always show legends for plotted series, and refresh layout after popup show and resize events.

- Testing
  Not run in this environment.

- Risks / Notes
  The analysis plot layout now depends on matplotlib tight_layout() instead of fixed subplot margins.
  Visualization popup label clipping should be improved, but real GUI validation is still useful to confirm spacing in different window sizes.

한국어
- 요약
  analysis 및 visualization 화면 전반에서 plot의 가독성과 일관성을 개선합니다.

- 변경 사항
  analysis plot에서 단일 series를 선택한 경우에도 범례가 표시되도록 했습니다.
  analysis popup과 visualization plot의 내부 그래프 제목을 제거했습니다.
  analysis plot은 고정 subplot margin 대신 redraw 시 tight_layout()을 사용하도록 변경했습니다.
  visualization plot은 y축 라벨을 Value로 통일하고, 단일 series도 범례가 보이도록 했으며, popup 표시 및 리사이즈 후 레이아웃을 다시 계산하도록 보강했습니다.

- 테스트
  이 환경에서는 실행하지 않았습니다.

- 리스크 / 참고사항
  analysis plot 레이아웃은 이제 고정 subplot margin 대신 matplotlib tight_layout() 동작에 의존합니다.
  visualization popup의 라벨 잘림은 개선되어야 하지만, 실제 GUI 환경에서 창 크기에 따른 여백과 배치를 추가 확인하는 것이 좋습니다.