### PR TITLE
Reorder visualization File menu actions

### DIFF
--- a/src/visualization/main_window.py
+++ b/src/visualization/main_window.py
@@ -99,14 +99,14 @@ class MainWindow(QMainWindow):
 
         # File Menu
         file_menu = menu_bar.addMenu("&File")
+        open_action = QAction("&Open Result File...", self)
+        open_action.triggered.connect(self.open_result_file)
+        file_menu.addAction(open_action)
+        file_menu.addSeparator()
         new_window_action = QAction("&New Visualization Window", self)
         new_window_action.setShortcut("Ctrl+N")
         new_window_action.triggered.connect(self.open_new_visualization_window)
         file_menu.addAction(new_window_action)
-        file_menu.addSeparator()
-        open_action = QAction("&Open Result File...", self)
-        open_action.triggered.connect(self.open_result_file)
-        file_menu.addAction(open_action)
         file_menu.addSeparator()
         exit_action = QAction("&Exit", self)
         exit_action.triggered.connect(self.close)


### PR DESCRIPTION
English
- Summary
  Reorder the File menu actions in the 3D visualization window to match the more common user flow.

- Changes
  Move Open Result File to the top of the File menu.
  Keep New Visualization Window as the secondary action below Open Result File.

- Testing
  Not run in this environment.

- Risks / Notes
  This change is limited to menu ordering and does not change the underlying file-open or window-creation behavior.

한국어
- 요약
  3D visualization 창의 File 메뉴 동작 순서를 실제 사용 흐름에 맞게 조정합니다.

- 변경 사항
  Open Result File을 File 메뉴 최상단으로 이동했습니다.
  New Visualization Window는 그 아래의 보조 동작으로 유지했습니다.

- 테스트
  이 환경에서는 실행하지 않았습니다.

- 리스크 / 참고사항
  이번 변경은 메뉴 순서만 조정하며, 파일 열기나 새 창 생성 동작 자체는 바꾸지 않습니다.