### PR TITLE
Fix Results Analysis plot resizing

### DIFF
--- a/src/analysis/ui/plot_manager.py
+++ b/src/analysis/ui/plot_manager.py
@@ -17,6 +17,7 @@ class PlotManager(QObject):
         self.ax = self.fig.add_subplot(111)
         self.span_selector = None
         self.annot = None
+        self.canvas.mpl_connect("resize_event", self._on_resize)
 
     def draw_plot(self, data_df: pd.DataFrame, columns_to_plot: list):
         self.ax.clear()
@@ -109,6 +110,11 @@ class PlotManager(QObject):
 
     def _on_select(self, xmin: float, xmax: float):
         self.region_changed_signal.emit(xmin, xmax)
+
+    def _on_resize(self, _event):
+        # Recompute subplot padding when the embedded canvas size changes.
+        self.fig.tight_layout()
+        self.canvas.draw_idle()
 
     def _place_hover_annotation(self, x, y):
         # Keep tooltip visible inside the plot area by flipping direction


### PR DESCRIPTION
English
- Summary
  Fix the Results Analysis plot so its layout updates when the embedded canvas is resized.

- Changes
  Listen for matplotlib canvas resize events in PlotManager.
  Reapply tight_layout() and redraw the analysis plot when the canvas size changes.

- Testing
  Ran:
  python -m py_compile src/analysis/ui/plot_manager.py

- Risks / Notes
  This change updates the resize path for analysis plots that use PlotManager.
  Real GUI verification is still useful to confirm the resized plot area now expands as expected.

한국어
- 요약
  Results Analysis의 플롯이 임베디드 canvas 리사이즈 시 레이아웃을 다시 계산하도록 수정합니다.

- 변경 사항
  PlotManager에서 matplotlib canvas resize event를 받도록 했습니다.
  canvas 크기가 바뀌면 analysis plot에 tight_layout()을 다시 적용하고 redraw 하도록 변경했습니다.

- 테스트
  실행:
  python -m py_compile src/analysis/ui/plot_manager.py

- 리스크 / 참고사항
  이번 변경은 PlotManager를 사용하는 analysis 플롯의 리사이즈 경로에 영향을 줍니다.
  실제 GUI에서 리사이즈 후 플롯 영역이 기대대로 확장되는지는 추가 확인이 있으면 좋습니다.