### PR TITLE
[codex] result resampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ python src/main.py
 실행 시 **Launcher Window**가 열리며, 여기서 아래 세 가지 흐름 중 하나를 시작할 수 있습니다.
 
 *   **Simulation**: MuJoCo를 활용하여 박스 크기/질량/낙하 조건을 설정하고 가상의 낙하 실험 데이터를 `.proc`로 생성
-*   **Data Processing**: 실제 원본 모션 캡처 데이터(CSV)를 불러와 분석하고 결과를 `.proc` 중심 workflow로 저장
+*   **Data Processing**: 실제 원본 모션 캡처 데이터(CSV)를 불러와 분석하고, 필요 시 최종 결과를 시간축에서 보간한 `.proc` 중심 workflow로 저장
 *   **3D Visualization**: 시뮬레이션에서 생성되거나 데이터 분석에서 추출된 `.proc` 결과 파일을 열어 3D/2D로 탐색
     *   런처 버튼을 반복 클릭하면 새 시각화 창이 추가로 열립니다.
     *   시각화 창 안에서는 `File > New Visualization Window`로 새 창을 바로 만들 수 있습니다.

--- a/docs/analysis/design/component_specs.txt
+++ b/docs/analysis/design/component_specs.txt
@@ -51,14 +51,14 @@ Last Reviewed: 2026-04-02
 *   책임:
     *   `.slice` 로드
     *   `.slice` 메타에서 box dimensions 복원
-    *   resampling / processing mode / advanced settings 수집
+    *   Result Resampling / 선택 구간 Result Resampling / processing mode / advanced settings 수집
     *   processing 실행 요청
     *   `.proc` 저장
 *   주요 UI 요소:
     *   `Load Slice File...`
     *   `Slice Summary`
     *   `Box Dimensions (mm)`
-    *   `Resampling`
+    *   `Result Resampling`
     *   `Processing Mode`
     *   `Run Processing`
     *   `Save Processed Result`
@@ -140,10 +140,12 @@ Last Reviewed: 2026-04-02
 ---
 *   위치: `src/analysis/pipeline/resampler.py`
 *   책임:
-    *   시간 인덱스를 기준으로 uniform grid 생성
+    *   기존 시간 인덱스 구간 사이에 보간 timestamp 생성
     *   numeric 컬럼 linear interpolation
     *   문자열/범주형 컬럼 ffill/bfill
     *   `Frame` 컬럼 재번호
+
+Result Resampling orchestration은 `PipelineController`가 담당한다. `UniformResampler`는 전달받은 최종 result DataFrame의 기존 timestamp를 포함한 채 중간 timestamp row를 보간하는 단일 책임을 유지한다.
 
 ---
 ### 12. 분석 모듈 집합

--- a/docs/analysis/design/gui_mockups/generate_analysis_gui_mockups.py
+++ b/docs/analysis/design/gui_mockups/generate_analysis_gui_mockups.py
@@ -786,7 +786,7 @@ class Step1SliceWorkflowMockWindow(QMainWindow):
         processing_layout.addLayout(mode_row)
 
         resampling_row = QHBoxLayout()
-        resampling_row.addWidget(QCheckBox("Enable Resampling"))
+        resampling_row.addWidget(QCheckBox("Enable Result Resampling"))
         resampling_factor = QComboBox()
         resampling_factor.addItems(["2x", "3x", "4x"])
         resampling_row.addWidget(resampling_factor)

--- a/docs/analysis/design/gui_overview.md
+++ b/docs/analysis/design/gui_overview.md
@@ -10,7 +10,7 @@ Last Reviewed: 2026-04-02
 - `Step 1: Raw Data Slice`
   - 원본 CSV 로드, 미리보기, 슬라이스 범위 지정, `.slice` 저장
 - `Step 1.5: Slice Processing`
-  - `.slice` 로드, processing mode / resampling 설정, processing 실행, `.proc` 저장
+  - `.slice` 로드, processing mode / Result Resampling 설정, processing 실행, `.proc` 저장
 - `Step 2: Results Analysis`
   - `.proc` 로드, 컬럼 선택 플롯, 팝업 플롯, 지점 분석, 시나리오 CSV 내보내기
 - 하단 `QStatusBar`는 파일 로드, 처리 진행, 저장 성공/실패 상태를 표시한다.
@@ -69,8 +69,10 @@ Last Reviewed: 2026-04-02
 ### 3.2. 하단 컨트롤
 - `Plot Options`
   - Step 1과 같은 preview 선택 구조를 유지한다
-- `Resampling`
-  - processing 전에 uniform time grid로 샘플을 보간할지 결정한다
+- `Result Resampling`
+  - processing 완료 후 최종 결과 컬럼을 시간축에서 보간할지 결정한다
+  - `Limit to Time Range`를 켜면 지정한 Start/End 시간 구간에만 중간 result row를 추가한다
+  - 기존 timestamp row의 결과값은 보존하고, 새 중간 timestamp row만 `.proc` 결과에 삽입한다
 - `Processing Mode`
   - Raw / Smoothing / Advanced
   - `Advanced Settings...` 다이얼로그 재사용
@@ -146,7 +148,7 @@ Last Reviewed: 2026-04-02
 2. 필요한 데이터와 축, 슬라이스 범위를 조정한다.
 3. `.slice`를 저장한다.
 4. Step 1.5에서 저장한 `.slice`를 연다.
-5. 필요하면 resampling factor와 processing mode를 조정한다.
+5. 필요하면 Result Resampling factor와 processing mode를 조정한다.
 6. processing을 실행한다.
 7. `.proc`를 저장한다.
 8. Step 2에서 결과 폴더를 선택하고 저장된 `.proc`를 목록에서 연다.

--- a/docs/analysis/design/gui_sketch.txt
+++ b/docs/analysis/design/gui_sketch.txt
@@ -48,7 +48,7 @@ Last Reviewed: 2026-04-02
 | | +---------------------------------------------+ +--------------------------------------------+ | |
 | |                                                                                                  | |
 | | +----------------------------+ +----------------------------+ +-------------------------------+ | |
-| | | Plot Options               | | Resampling                 | | Processing Mode               | | |
+| | | Plot Options               | | Result Resampling          | | Processing Mode               | | |
 | | | [Select Data...]           | | [ ] Enable  [2x v]         | | Raw / Smoothing / Advanced   | | |
 | | | Selected: RigidBody Center | |                            | | [Advanced Settings...]        | | |
 | | | Axis: [Position-X v]       | |                            | |                               | | |

--- a/docs/analysis/design/system_design.md
+++ b/docs/analysis/design/system_design.md
@@ -31,7 +31,7 @@ Last Reviewed: 2026-04-02
 ### 3.2. Step 1.5: Slice Processing
 - `.slice` 로드
 - `.slice` 메타에 포함된 box dimensions 자동 적용
-- Optional uniform resampling 지정
+- Optional Result Resampling 지정
 - `Processing Mode` 선택 (`Raw / Smoothing / Advanced`)
 - `Advanced Settings...` 다이얼로그 사용
 - processing 실행
@@ -63,7 +63,7 @@ Last Reviewed: 2026-04-02
 ### 4.1. 파이프라인 제어와 UI 분리
 - UI는 설정 수집과 결과 표시를 담당한다.
 - 실제 분석 순서 제어는 `PipelineController`가 담당한다.
-- resampling factor 기반 옵션 보정 규칙처럼 UI/Qt와 무관한 계산 로직은 순수 모듈로 분리한다.
+- Result Resampling처럼 UI/Qt와 무관한 계산 로직은 순수 모듈로 분리한다.
 - processing mode 라벨과 기본 preset 같은 UI 정책은 `src/config/config_analysis_ui.py`에서 관리한다.
 
 ### 4.2. 컬럼 정의의 중앙 관리
@@ -76,7 +76,9 @@ Last Reviewed: 2026-04-02
 - 단, 사용자 workflow 개선을 위해 scene 재사용용 `.slice`와 processed result 재사용용 `.proc`를 도입한다.
 - `.slice`는 raw CSV 구조를 유지한 scene 파일이다.
 - `.proc`는 기존 result CSV와 같은 multi-header 결과 구조를 사용한다.
-- resampling을 사용하는 경우에도 parsed slice 이후 DataFrame을 uniform time grid로 재구성한 뒤 후속 분석을 수행한다.
+- Result Resampling을 사용하는 경우에는 전체 slice baseline processing 결과를 먼저 만들고, 최종 결과 컬럼을 보간해 새 중간 timestamp row만 merge한다.
+- `Limit to Time Range`가 켜진 경우에는 지정 구간 안에서만 중간 result row를 추가하고, 꺼진 경우에는 전체 slice 결과 구간에 추가한다.
+- Result Resampling은 분석 정확도 향상 기능이 아니라 결과 시간축 보간 기능이며, 기존 timestamp의 position/velocity/acceleration/analysis 값은 유지한다.
 
 ### 4.4. 분석 단계와 후처리의 분리
 - Step 1은 "원본에서 scene slice 만들기"에 집중한다.

--- a/docs/analysis/design/workflow.txt
+++ b/docs/analysis/design/workflow.txt
@@ -50,7 +50,7 @@ Last Reviewed: 2026-03-18
    |
    +-----> [Processing Mode 선택]
    +-----> [Advanced Settings 조정]
-   +-----> [Resampling factor 선택]
+   +-----> [Result Resampling factor / range 선택]
    |
    V
 [8. 사용자가 "Run Processing" 클릭]

--- a/docs/analysis/reference/pipeline_data_structures.txt
+++ b/docs/analysis/reference/pipeline_data_structures.txt
@@ -16,6 +16,11 @@ Last Reviewed: 2026-03-08
     *   `slice_filter_by`: 현재는 `'time'` 고정
     *   `slice_start_val`: 분석 시작 시각(초)
     *   `slice_end_val`: 분석 종료 시각(초)
+    *   `enable_result_resampling`: Result Resampling 사용 여부
+    *   `result_resampling_factor`: 중간 result row 추가 배율
+    *   `limit_result_resampling_to_range`: 지정 시간 구간에만 Result Resampling을 적용할지 여부
+    *   `result_resampling_range_start`: 선택 구간 Result Resampling 시작 시각(초)
+    *   `result_resampling_range_end`: 선택 구간 Result Resampling 종료 시각(초)
 
 이 설정은 `MainApp.run_pipeline()`을 거쳐 `PipelineController.run_analysis()`에 전달된다.
 
@@ -47,6 +52,7 @@ Last Reviewed: 2026-03-08
     5. `VelocityCalculator`가 Velocity / Acceleration 컬럼을 계산
     6. `FrameAnalyzer`가 Analysis 컬럼을 계산
 *   각 단계는 입력 DataFrame에 컬럼을 추가하거나 수정한 뒤 반환한다.
+*   Result Resampling을 사용하는 경우 `PipelineController`는 전체 slice baseline 결과를 만든 뒤, 최종 결과 컬럼을 보간해 중간 timestamp row만 삽입한다. 기존 timestamp row 값은 baseline 결과를 유지한다.
 
 ---
 ### 4. 결과 컬럼 체계

--- a/src/analysis/pipeline/pipeline_controller.py
+++ b/src/analysis/pipeline/pipeline_controller.py
@@ -1,7 +1,8 @@
+import numpy as np
 import pandas as pd
 from PySide6.QtCore import QObject, Signal
 from src.config import config_app, config_analysis
-from src.config.data_columns import FACE_PREFIX_TO_INFO
+from src.config.data_columns import FACE_PREFIX_TO_INFO, TimeCols
 from src.analysis.pipeline.slicer import Slicer
 from src.analysis.pipeline.parser import Parser
 from src.analysis.pipeline.smoother import MarkerSmoother
@@ -34,14 +35,14 @@ class PipelineController(QObject):
         )
 
     def _execute_analysis_from_parsed(self, gui_config: dict, parsed_data: pd.DataFrame) -> pd.DataFrame:
+        if self._is_result_resampling_enabled(gui_config):
+            return self._execute_result_resampling(gui_config, parsed_data)
+        return self._execute_analysis_single_pass(gui_config, parsed_data)
+
+    def _execute_analysis_single_pass(self, gui_config: dict, parsed_data: pd.DataFrame) -> pd.DataFrame:
         analysis_options = gui_config.get('analysis_options', {})
         processing_mode = gui_config.get('processing_mode', 'standard')
-        resampling_enabled = bool(gui_config.get('enable_resampling', False))
-        resampling_factor = int(gui_config.get('resampling_factor') or 1)
-        effective_analysis_options = build_effective_analysis_options(
-            analysis_options,
-            resampling_factor if resampling_enabled else 1,
-        )
+        effective_analysis_options = build_effective_analysis_options(analysis_options, 1)
         self.smoother.configure(effective_analysis_options)
         self.velocity_calculator.configure(effective_analysis_options)
 
@@ -87,25 +88,6 @@ class PipelineController(QObject):
         )
         padded_data = slicer_for_padding.process(data)
         self.log_message.emit(f"    Padded slicer done. Shape: {padded_data.shape}")
-
-        if resampling_enabled and resampling_factor > 1:
-            self.log_message.emit("[2.5/8] Resampling data on a uniform time grid...")
-            resampler = UniformResampler(resampling_factor)
-            original_rows = len(padded_data)
-            original_mean_dt = (
-                float(pd.Series(padded_data.index).diff().dropna().mean())
-                if len(padded_data) > 1
-                else 0.0
-            )
-            padded_data = resampler.process(padded_data)
-            new_mean_dt = (
-                float(pd.Series(padded_data.index).diff().dropna().mean())
-                if len(padded_data) > 1
-                else 0.0
-            )
-            self.log_message.emit(f"    Resampling factor: {resampling_factor}x")
-            self.log_message.emit(f"    Rows: {original_rows} -> {len(padded_data)}")
-            self.log_message.emit(f"    Mean dt: {original_mean_dt:.6f}s -> {new_mean_dt:.6f}s")
 
         # 3. 스무딩
         if effective_analysis_options.get('enable_marker_smoothing', True):
@@ -158,6 +140,119 @@ class PipelineController(QObject):
 
         self.log_message.emit("\nAnalysis pipeline completed successfully.")
         return final_result
+
+    def _is_result_resampling_enabled(self, gui_config: dict) -> bool:
+        enabled = gui_config.get('enable_result_resampling', gui_config.get('enable_resampling', False))
+        return bool(enabled) and self._get_result_resampling_factor(gui_config) > 1
+
+    def _get_result_resampling_factor(self, gui_config: dict) -> int:
+        return int(gui_config.get('result_resampling_factor', gui_config.get('resampling_factor') or 1) or 1)
+
+    def _is_result_resampling_range_limited(self, gui_config: dict) -> bool:
+        return bool(
+            gui_config.get(
+                'limit_result_resampling_to_range',
+                gui_config.get('limit_resampling_to_range', False),
+            )
+        )
+
+    def _copy_config_for_pass(self, gui_config: dict, **overrides) -> dict:
+        pass_config = dict(gui_config)
+        pass_config['analysis_options'] = dict(gui_config.get('analysis_options', {}))
+        pass_config.update(overrides)
+        pass_config['enable_result_resampling'] = False
+        pass_config['limit_result_resampling_to_range'] = False
+        pass_config['result_resampling_factor'] = 1
+        # Legacy key fallback: make sure a baseline pass never performs old input resampling.
+        pass_config['enable_resampling'] = False
+        pass_config['limit_resampling_to_range'] = False
+        pass_config['resampling_factor'] = 1
+        return pass_config
+
+    def _validate_resampling_range(self, gui_config: dict, parsed_data: pd.DataFrame) -> tuple[float, float]:
+        original_start = float(gui_config.get('slice_start_val'))
+        original_end = float(gui_config.get('slice_end_val'))
+        range_start = gui_config.get('result_resampling_range_start', gui_config.get('resampling_range_start'))
+        range_end = gui_config.get('result_resampling_range_end', gui_config.get('resampling_range_end'))
+        if range_start is None or range_end is None:
+            raise ValueError("Range-limited result resampling requires start and end times.")
+
+        range_start = float(range_start)
+        range_end = float(range_end)
+        if range_start >= range_end:
+            raise ValueError("Result resampling range start must be smaller than end.")
+
+        tolerance = 1e-9
+        if range_start < original_start - tolerance or range_end > original_end + tolerance:
+            raise ValueError("Result resampling range must stay inside the selected slice range.")
+
+        data_min = float(parsed_data.index.min())
+        data_max = float(parsed_data.index.max())
+        if range_start < data_min - tolerance or range_end > data_max + tolerance:
+            raise ValueError("Result resampling range must stay inside the loaded slice data.")
+
+        return range_start, range_end
+
+    def _merge_result_resampling_rows(
+        self,
+        baseline_result: pd.DataFrame,
+        resampled_result: pd.DataFrame,
+        range_start: float,
+        range_end: float,
+    ) -> pd.DataFrame:
+        if baseline_result.empty or resampled_result.empty:
+            return baseline_result.copy()
+
+        baseline_index = baseline_result.index.to_numpy(dtype=float)
+        resampled_index = resampled_result.index.to_numpy(dtype=float)
+        tolerance = 1e-9
+        inside_range = (resampled_index >= range_start - tolerance) & (resampled_index <= range_end + tolerance)
+        new_timestamp_mask = np.array(
+            [not np.any(np.isclose(timestamp, baseline_index, rtol=0.0, atol=tolerance)) for timestamp in resampled_index]
+        )
+        rows_to_insert = resampled_result.loc[inside_range & new_timestamp_mask]
+
+        merged = pd.concat([baseline_result, rows_to_insert], axis=0).sort_index(kind='mergesort')
+        merged = merged[~merged.index.duplicated(keep='first')].copy()
+        if TimeCols.FRAME in merged.columns:
+            merged[TimeCols.FRAME] = np.arange(len(merged), dtype=int)
+        return merged
+
+    def _execute_result_resampling(self, gui_config: dict, parsed_data: pd.DataFrame) -> pd.DataFrame:
+        resampling_factor = self._get_result_resampling_factor(gui_config)
+        baseline_config = self._copy_config_for_pass(gui_config)
+        self.log_message.emit("[INFO] Running baseline processing before result resampling...")
+        baseline_result = self._execute_analysis_single_pass(baseline_config, parsed_data)
+
+        if self._is_result_resampling_range_limited(gui_config):
+            range_start, range_end = self._validate_resampling_range(gui_config, parsed_data)
+            self.log_message.emit(
+                "[INFO] Result resampling enabled for selected range: "
+                f"{range_start:.3f}s - {range_end:.3f}s at {resampling_factor}x"
+            )
+            result_to_resample = baseline_result.loc[range_start:range_end]
+        else:
+            range_start = float(baseline_result.index.min())
+            range_end = float(baseline_result.index.max())
+            self.log_message.emit(
+                "[INFO] Result resampling enabled for full slice: "
+                f"{range_start:.3f}s - {range_end:.3f}s at {resampling_factor}x"
+            )
+            result_to_resample = baseline_result
+
+        self.log_message.emit("[INFO] Interpolating processed result rows...")
+        resampled_result = UniformResampler(resampling_factor).process(result_to_resample)
+
+        merged = self._merge_result_resampling_rows(
+            baseline_result,
+            resampled_result,
+            range_start,
+            range_end,
+        )
+        inserted_rows = len(merged) - len(baseline_result)
+        self.log_message.emit(f"[INFO] Inserted {inserted_rows} interpolated result rows.")
+        self.log_message.emit("\nResult resampling pipeline completed successfully.")
+        return merged
 
     def process_parsed_data(self, gui_config: dict, parsed_data: pd.DataFrame) -> pd.DataFrame:
         return self._execute_analysis_from_parsed(gui_config, parsed_data)

--- a/src/analysis/pipeline/resampler.py
+++ b/src/analysis/pipeline/resampler.py
@@ -19,8 +19,13 @@ class UniformResampler:
             raise ValueError("Resampling requires a strictly increasing time index.")
 
         new_size = (len(original_index) - 1) * self.factor + 1
-        new_index = np.linspace(original_index[0], original_index[-1], new_size)
-        resampled = pd.DataFrame(index=pd.Index(new_index, name=df.index.name))
+        new_index_parts = []
+        for start, end in zip(original_index[:-1], original_index[1:]):
+            step = (end - start) / self.factor
+            new_index_parts.extend(start + step * offset for offset in range(self.factor))
+        new_index_parts.append(original_index[-1])
+        new_index = np.asarray(new_index_parts, dtype=float)
+        resampled_columns = {}
 
         for column in df.columns:
             series = df[column]
@@ -29,14 +34,20 @@ class UniformResampler:
             if numeric_series.notna().any():
                 valid = numeric_series.dropna()
                 if len(valid) == 1:
-                    resampled[column] = np.full(new_size, float(valid.iloc[0]))
+                    resampled_columns[column] = np.full(new_size, float(valid.iloc[0]))
                 else:
-                    resampled[column] = np.interp(new_index, valid.index.to_numpy(dtype=float), valid.to_numpy(dtype=float))
+                    resampled_columns[column] = np.interp(
+                        new_index,
+                        valid.index.to_numpy(dtype=float),
+                        valid.to_numpy(dtype=float),
+                    )
                 continue
 
-            expanded = series.reindex(series.index.union(resampled.index)).sort_index()
+            expanded = series.reindex(series.index.union(new_index)).sort_index()
             filled = expanded.ffill().bfill()
-            resampled[column] = filled.reindex(resampled.index)
+            resampled_columns[column] = filled.reindex(new_index).to_numpy()
+
+        resampled = pd.DataFrame(resampled_columns, index=pd.Index(new_index, name=df.index.name))
 
         if TimeCols.FRAME in resampled.columns:
             resampled[TimeCols.FRAME] = np.arange(len(resampled), dtype=int)

--- a/src/analysis/ui/widget_slice_processing.py
+++ b/src/analysis/ui/widget_slice_processing.py
@@ -1,6 +1,7 @@
 import os
 
 from PySide6.QtCore import Signal, Qt
+from PySide6.QtGui import QDoubleValidator
 from PySide6.QtWidgets import (
     QApplication,
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
@@ -136,7 +137,7 @@ class WidgetSliceProcessing(QWidget):
         controls_widget = QWidget()
         h_controls_layout = QHBoxLayout(controls_widget)
         controls_widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
-        controls_widget.setMinimumHeight(180)
+        controls_widget.setMinimumHeight(220)
 
         plot_options_group = QGroupBox("Plot Options")
         plot_options_layout = QVBoxLayout(plot_options_group)
@@ -169,6 +170,19 @@ class WidgetSliceProcessing(QWidget):
             self.combo_resampling_factor.addItem(label, userData=factor)
         self.combo_resampling_factor.setEnabled(False)
         resampling_layout.addWidget(self.combo_resampling_factor, 1, 1)
+        self.cb_limit_resampling_range = QCheckBox(config_analysis_ui.RESAMPLING_RANGE_ENABLE_LABEL)
+        self.cb_limit_resampling_range.setEnabled(False)
+        resampling_layout.addWidget(self.cb_limit_resampling_range, 2, 0, 1, 2)
+        resampling_layout.addWidget(QLabel(config_analysis_ui.RESAMPLING_RANGE_START_LABEL), 3, 0)
+        self.le_resampling_range_start = QLineEdit()
+        self.le_resampling_range_start.setValidator(QDoubleValidator(self))
+        self.le_resampling_range_start.setEnabled(False)
+        resampling_layout.addWidget(self.le_resampling_range_start, 3, 1)
+        resampling_layout.addWidget(QLabel(config_analysis_ui.RESAMPLING_RANGE_END_LABEL), 4, 0)
+        self.le_resampling_range_end = QLineEdit()
+        self.le_resampling_range_end.setValidator(QDoubleValidator(self))
+        self.le_resampling_range_end.setEnabled(False)
+        resampling_layout.addWidget(self.le_resampling_range_end, 4, 1)
         self.resampling_description = QLabel(config_analysis_ui.RESAMPLING_DESCRIPTION)
         self.resampling_description.setWordWrap(True)
         self.resampling_description.setStyleSheet("color: #4a5568;")
@@ -176,7 +190,7 @@ class WidgetSliceProcessing(QWidget):
             config_analysis_ui.RAW_DATA_PROCESSING_LAYOUT["resampling_description_fixed_height"]
         )
         self.resampling_description.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
-        resampling_layout.addWidget(self.resampling_description, 2, 0, 1, 2)
+        resampling_layout.addWidget(self.resampling_description, 5, 0, 1, 2)
         h_controls_layout.addWidget(self.resampling_group)
 
         processing_group = QGroupBox(config_analysis_ui.PROCESSING_MODE_GROUP_TITLE)
@@ -294,7 +308,8 @@ class WidgetSliceProcessing(QWidget):
         self.load_slice_button.clicked.connect(self.open_slice_file)
         self.select_data_button.clicked.connect(self.open_data_selection_dialog)
         self.combo_plot_axis.currentIndexChanged.connect(self.update_plot)
-        self.cb_enable_resampling.toggled.connect(self.combo_resampling_factor.setEnabled)
+        self.cb_enable_resampling.toggled.connect(self._update_resampling_controls_enabled)
+        self.cb_limit_resampling_range.toggled.connect(self._update_resampling_controls_enabled)
         self.rb_processing_standard.toggled.connect(self._on_processing_mode_changed)
         self.rb_processing_raw.toggled.connect(self._on_processing_mode_changed)
         self.rb_processing_advanced.toggled.connect(self._on_processing_mode_changed)
@@ -321,6 +336,50 @@ class WidgetSliceProcessing(QWidget):
         self.slice_padded_range_label.setText(
             f"{self.slice_metadata.padded_start:.3f}s ~ {self.slice_metadata.padded_end:.3f}s"
         )
+        self._set_default_resampling_range()
+
+    def _set_default_resampling_range(self, metadata=None):
+        metadata = self.slice_metadata if metadata is None else metadata
+        if metadata is not None:
+            start = metadata.user_start
+            end = metadata.user_end
+        elif self.parsed_data is not None and not self.parsed_data.empty:
+            start = float(self.parsed_data.index.min())
+            end = float(self.parsed_data.index.max())
+        else:
+            start = None
+            end = None
+
+        if start is not None and end is not None:
+            self.le_resampling_range_start.setText(f"{float(start):.3f}")
+            self.le_resampling_range_end.setText(f"{float(end):.3f}")
+
+    def _update_resampling_controls_enabled(self):
+        resampling_enabled = self.cb_enable_resampling.isChecked()
+        range_enabled = resampling_enabled and self.cb_limit_resampling_range.isChecked()
+        self.combo_resampling_factor.setEnabled(resampling_enabled)
+        self.cb_limit_resampling_range.setEnabled(resampling_enabled)
+        self.le_resampling_range_start.setEnabled(range_enabled)
+        self.le_resampling_range_end.setEnabled(range_enabled)
+
+    def _get_resampling_range_values(self, parsed_data, metadata=None) -> tuple[float | None, float | None]:
+        if not (self.cb_enable_resampling.isChecked() and self.cb_limit_resampling_range.isChecked()):
+            return None, None
+
+        try:
+            range_start = float(self.le_resampling_range_start.text())
+            range_end = float(self.le_resampling_range_end.text())
+        except ValueError:
+            raise ValueError("Enter numeric resampling range start/end times.")
+
+        metadata = self.slice_metadata if metadata is None else metadata
+        slice_start = metadata.user_start if metadata else float(parsed_data.index.min())
+        slice_end = metadata.user_end if metadata else float(parsed_data.index.max())
+        if range_start >= range_end:
+            raise ValueError("Result resampling range start must be smaller than end.")
+        if range_start < float(slice_start) or range_end > float(slice_end):
+            raise ValueError("Result resampling range must stay inside the slice user range.")
+        return range_start, range_end
 
     def _apply_box_dims_from_metadata(self, metadata=None):
         metadata = self.slice_metadata if metadata is None else metadata
@@ -500,6 +559,7 @@ class WidgetSliceProcessing(QWidget):
 
     def _build_processing_config(self, parsed_data, metadata=None) -> dict:
         metadata = self.slice_metadata if metadata is None else metadata
+        range_start, range_end = self._get_resampling_range_values(parsed_data, metadata)
         return {
             "slice_filter_by": "time",
             "slice_start_val": (
@@ -508,9 +568,15 @@ class WidgetSliceProcessing(QWidget):
             "slice_end_val": (
                 metadata.user_end if metadata else float(parsed_data.index.max())
             ),
-            "enable_resampling": self.cb_enable_resampling.isChecked(),
-            "resampling_factor": self.combo_resampling_factor.currentData(),
-            "resampling_method": "linear",
+            "enable_result_resampling": self.cb_enable_resampling.isChecked(),
+            "result_resampling_factor": self.combo_resampling_factor.currentData(),
+            "result_resampling_method": "linear",
+            "limit_result_resampling_to_range": (
+                self.cb_enable_resampling.isChecked()
+                and self.cb_limit_resampling_range.isChecked()
+            ),
+            "result_resampling_range_start": range_start,
+            "result_resampling_range_end": range_end,
             "processing_mode": self.current_processing_mode,
             "analysis_options": self._build_analysis_overrides(),
         }

--- a/src/config/config_analysis_ui.py
+++ b/src/config/config_analysis_ui.py
@@ -20,7 +20,7 @@ RESAMPLING_RANGE_ENABLE_LABEL = "Limit to Time Range"
 RESAMPLING_RANGE_START_LABEL = "Start (s):"
 RESAMPLING_RANGE_END_LABEL = "End (s):"
 RESAMPLING_DESCRIPTION = (
-    "Adds interpolated result rows after processing. Original sample results are preserved."
+    "Adds interpolated result rows after processing."
 )
 RESAMPLING_FACTOR_CHOICES = [
     ("2x", 2),

--- a/src/config/config_analysis_ui.py
+++ b/src/config/config_analysis_ui.py
@@ -11,13 +11,16 @@ PROCESSING_MODE_ORDER = [
 ]
 
 PROCESSING_MODE_GROUP_TITLE = "Processing Mode"
-RESAMPLING_GROUP_TITLE = "Resampling"
+RESAMPLING_GROUP_TITLE = "Result Resampling"
 ADVANCED_DIALOG_TITLE = "Advanced Processing Settings"
 ADVANCED_BUTTON_TEXT = "Advanced Settings..."
-RESAMPLING_ENABLE_LABEL = "Enable Resampling"
+RESAMPLING_ENABLE_LABEL = "Enable Result Resampling"
 RESAMPLING_FACTOR_LABEL = "Factor:"
+RESAMPLING_RANGE_ENABLE_LABEL = "Limit to Time Range"
+RESAMPLING_RANGE_START_LABEL = "Start (s):"
+RESAMPLING_RANGE_END_LABEL = "End (s):"
 RESAMPLING_DESCRIPTION = (
-    "Adds uniformly interpolated samples before analysis to increase temporal resolution."
+    "Adds interpolated result rows after processing. Original sample results are preserved."
 )
 RESAMPLING_FACTOR_CHOICES = [
     ("2x", 2),
@@ -43,10 +46,10 @@ PROCESSING_MODE_DESCRIPTIONS = {
 RAW_DATA_PROCESSING_LAYOUT = {
     "plot_options_group_min_width": 360,
     "slice_group_min_width": 280,
-    "resampling_group_min_width": 280,
+    "resampling_group_min_width": 320,
     "processing_group_min_width": 320,
     "processing_mode_description_fixed_height": 42,
-    "resampling_description_fixed_height": 42,
+    "resampling_description_fixed_height": 48,
     "bottom_controls_stretch": [4, 3, 3, 4, 2],
     "processing_settings_button_min_width": 150,
 }

--- a/tests/test_range_limited_resampling.py
+++ b/tests/test_range_limited_resampling.py
@@ -1,0 +1,118 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from src.analysis.pipeline.resampler import UniformResampler
+from src.config.data_columns import TimeCols
+
+try:
+    from src.analysis.pipeline.pipeline_controller import PipelineController
+    HAS_QT = True
+except ModuleNotFoundError:
+    PipelineController = object
+    HAS_QT = False
+
+
+class _DeterministicRangeController(PipelineController):
+    def _execute_analysis_single_pass(self, gui_config: dict, parsed_data: pd.DataFrame) -> pd.DataFrame:
+        start = float(gui_config["slice_start_val"])
+        end = float(gui_config["slice_end_val"])
+        subset = parsed_data.loc[start:end].copy()
+
+        time_values = subset.index.to_numpy(dtype=float)
+        return pd.DataFrame(
+            {
+                TimeCols.FRAME: np.arange(len(subset), dtype=int),
+                "Metric": time_values,
+            },
+            index=pd.Index(time_values, name=TimeCols.TIME),
+        )
+
+
+@unittest.skipUnless(HAS_QT, "PySide6 is required for PipelineController tests.")
+class TestRangeLimitedResampling(unittest.TestCase):
+    def _parsed_data(self):
+        times = np.round(np.arange(0.0, 1.01, 0.1), 10)
+        return pd.DataFrame(
+            {TimeCols.FRAME: np.arange(len(times), dtype=int), "Raw": times},
+            index=pd.Index(times, name=TimeCols.TIME),
+        )
+
+    def _config(self):
+        return {
+            "slice_filter_by": "time",
+            "slice_start_val": 0.0,
+            "slice_end_val": 1.0,
+            "enable_result_resampling": True,
+            "result_resampling_factor": 2,
+            "limit_result_resampling_to_range": True,
+            "result_resampling_range_start": 0.3,
+            "result_resampling_range_end": 0.6,
+            "analysis_options": {},
+        }
+
+    def test_range_limited_resampling_preserves_existing_samples_and_inserts_only_middle_rows(self):
+        controller = _DeterministicRangeController()
+        parsed_data = self._parsed_data()
+
+        baseline = controller._execute_analysis_single_pass(
+            {**self._config(), "enable_result_resampling": False, "result_resampling_factor": 1},
+            parsed_data,
+        )
+        result = controller._execute_analysis_from_parsed(self._config(), parsed_data)
+
+        self.assertEqual(float(result.index.min()), 0.0)
+        self.assertEqual(float(result.index.max()), 1.0)
+        self.assertGreater(len(result), len(baseline))
+        np.testing.assert_array_equal(result[TimeCols.FRAME].to_numpy(), np.arange(len(result)))
+
+        inserted_times = result.index.difference(baseline.index)
+        self.assertTrue((inserted_times >= 0.3).all())
+        self.assertTrue((inserted_times <= 0.6).all())
+        self.assertGreater(len(inserted_times), 0)
+
+        preserved = result.loc[baseline.index, "Metric"]
+        pd.testing.assert_series_equal(preserved, baseline["Metric"], check_names=False)
+        np.testing.assert_allclose(
+            result.loc[inserted_times, "Metric"].to_numpy(dtype=float),
+            inserted_times.to_numpy(dtype=float),
+        )
+
+    def test_range_limited_resampling_rejects_invalid_range(self):
+        controller = _DeterministicRangeController()
+        config = self._config()
+        config["result_resampling_range_start"] = 0.7
+        config["result_resampling_range_end"] = 0.6
+
+        with self.assertRaisesRegex(ValueError, "start must be smaller"):
+            controller._execute_analysis_from_parsed(config, self._parsed_data())
+
+    def test_full_result_resampling_preserves_existing_samples_and_inserts_across_slice(self):
+        controller = _DeterministicRangeController()
+        parsed_data = self._parsed_data()
+        config = self._config()
+        config["limit_result_resampling_to_range"] = False
+        config["result_resampling_range_start"] = None
+        config["result_resampling_range_end"] = None
+
+        baseline = controller._execute_analysis_single_pass(
+            {**config, "enable_result_resampling": False, "result_resampling_factor": 1},
+            parsed_data,
+        )
+        result = controller._execute_analysis_from_parsed(config, parsed_data)
+
+        self.assertEqual(len(result), 21)
+        inserted_times = result.index.difference(baseline.index)
+        self.assertGreater(len(inserted_times), 0)
+        self.assertEqual(float(inserted_times.min()), 0.05)
+        self.assertEqual(float(inserted_times.max()), 0.95)
+        pd.testing.assert_series_equal(
+            result.loc[baseline.index, "Metric"],
+            baseline["Metric"],
+            check_names=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resampler.py
+++ b/tests/test_resampler.py
@@ -27,6 +27,21 @@ class TestUniformResampler(unittest.TestCase):
         self.assertEqual(result["Marker_FaceInfo"].isna().sum(), 0)
         self.assertTrue((result["Marker_FaceInfo"] == "TOP").all())
 
+    def test_resampler_preserves_original_timestamps_for_nonuniform_input(self):
+        df = pd.DataFrame(
+            {
+                TimeCols.FRAME: [0, 1, 2],
+                "Value": [0.0, 10.0, 30.0],
+            },
+            index=pd.Index([0.0, 0.1, 0.35], name=TimeCols.TIME),
+        )
+
+        result = UniformResampler(factor=2).process(df)
+
+        for timestamp in df.index:
+            self.assertIn(timestamp, result.index)
+            self.assertEqual(result.loc[timestamp, "Value"], df.loc[timestamp, "Value"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_slice_batch_processing.py
+++ b/tests/test_slice_batch_processing.py
@@ -107,6 +107,29 @@ class TestSliceBatchProcessing(unittest.TestCase):
             self.assertIn("skipped=1", self.widget.batch_summary_label.text())
             self.assertIn("failed=0", self.widget.batch_summary_label.text())
 
+    def test_processing_config_includes_range_limited_resampling_settings(self):
+        self.widget.slice_metadata = self._metadata()
+        parsed_data = pd.DataFrame(index=pd.Index([0.0, 0.5, 1.0], name="Time"))
+        self.widget.cb_enable_resampling.setChecked(True)
+        self.widget.cb_limit_resampling_range.setChecked(True)
+        self.widget.le_resampling_range_start.setText("0.2")
+        self.widget.le_resampling_range_end.setText("0.8")
+
+        config = self.widget._build_processing_config(parsed_data, self.widget.slice_metadata)
+
+        self.assertTrue(config["enable_result_resampling"])
+        self.assertTrue(config["limit_result_resampling_to_range"])
+        self.assertEqual(config["result_resampling_range_start"], 0.2)
+        self.assertEqual(config["result_resampling_range_end"], 0.8)
+
+    def test_slice_summary_sets_default_resampling_range_from_metadata(self):
+        self.widget.slice_metadata = self._metadata()
+
+        self.widget._set_slice_summary()
+
+        self.assertEqual(self.widget.le_resampling_range_start.text(), "0.100")
+        self.assertEqual(self.widget.le_resampling_range_end.text(), "0.900")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Summary

- Reworked Step 1.5 resampling into Result Resampling so the pipeline processes the original slice once and interpolates final result rows afterward.
- Added optional time-range-limited Result Resampling in the Slice Processing UI.
- Updated docs and tests to match the new behavior.

# Validation

- `python -m py_compile src/analysis/pipeline/pipeline_controller.py src/analysis/pipeline/resampler.py src/analysis/ui/widget_slice_processing.py src/config/config_analysis_ui.py tests/test_range_limited_resampling.py tests/test_slice_batch_processing.py tests/test_resampler.py`
- `python -m unittest tests.test_resampler tests.test_pipeline_resampling_options tests.test_processing_mode_config`
- `python -m unittest tests.test_range_limited_resampling tests.test_slice_batch_processing` (PySide6 missing, tests skipped)
- Real CSV validation on `TestSets/Input/VDTest_S5_001.csv`: full and range Result Resampling preserved original timestamp result values with `max_abs_diff = 0`
