### PR TITLE
feat(ui): add WIP warning to simulation button

### DIFF
--- a/src/launcher.py
+++ b/src/launcher.py
@@ -58,10 +58,19 @@ class LauncherWindow(QMainWindow):
         right_panel_layout.setSpacing(14)
         right_panel_layout.addStretch(1)
 
-        self.btn_simulation = QPushButton("Run Simulation")
+        self.btn_simulation = QPushButton("Run Simulation (WIP)")
         self.btn_simulation.clicked.connect(self.open_simulation)
         self.btn_simulation.setFixedSize(320, 50)
         right_panel_layout.addWidget(self.btn_simulation, 0, Qt.AlignHCenter)
+
+        self.simulation_warning_label = QLabel(
+            "⚠️ Work in progress. Please do not use this for actual tasks."
+        )
+        self.simulation_warning_label.setWordWrap(True)
+        self.simulation_warning_label.setAlignment(Qt.AlignCenter)
+        self.simulation_warning_label.setFixedWidth(320)
+        self.simulation_warning_label.setStyleSheet("color: #e53e3e; font-size: 11px;")
+        right_panel_layout.addWidget(self.simulation_warning_label, 0, Qt.AlignHCenter)
 
         self.btn_data_processing = QPushButton(config.LAUNCHER_BTN_PROCESS_TEXT)
         self.btn_data_processing.clicked.connect(self.open_data_processing)

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -58,19 +58,26 @@ class LauncherWindow(QMainWindow):
         right_panel_layout.setSpacing(14)
         right_panel_layout.addStretch(1)
 
+        sim_layout = QVBoxLayout()
+        sim_layout.setContentsMargins(0, 0, 0, 0)
+        sim_layout.setSpacing(2)
+
         self.btn_simulation = QPushButton("Run Simulation (WIP)")
         self.btn_simulation.clicked.connect(self.open_simulation)
         self.btn_simulation.setFixedSize(320, 50)
-        right_panel_layout.addWidget(self.btn_simulation, 0, Qt.AlignHCenter)
+        sim_layout.addWidget(self.btn_simulation, 0, Qt.AlignHCenter)
 
         self.simulation_warning_label = QLabel(
             "⚠️ Work in progress. Please do not use this for actual tasks."
         )
         self.simulation_warning_label.setWordWrap(True)
-        self.simulation_warning_label.setAlignment(Qt.AlignCenter)
+        self.simulation_warning_label.setAlignment(Qt.AlignTop | Qt.AlignHCenter)
         self.simulation_warning_label.setFixedWidth(320)
         self.simulation_warning_label.setStyleSheet("color: #e53e3e; font-size: 11px;")
-        right_panel_layout.addWidget(self.simulation_warning_label, 0, Qt.AlignHCenter)
+        sim_layout.addWidget(self.simulation_warning_label, 0, Qt.AlignHCenter)
+
+        right_panel_layout.addLayout(sim_layout)
+        right_panel_layout.addSpacing(8)
 
         self.btn_data_processing = QPushButton(config.LAUNCHER_BTN_PROCESS_TEXT)
         self.btn_data_processing.clicked.connect(self.open_data_processing)


### PR DESCRIPTION
Added a WIP warning to the 'Run Simulation' button to prevent users from relying on the incomplete feature. Changed button text to indicate WIP and added a clear warning label below it.