### PR TITLE
fix(ui): enforce slice box dimensions in Step 1.5 processing

### DIFF
--- a/docs/analysis/design/component_specs.txt
+++ b/docs/analysis/design/component_specs.txt
@@ -2,7 +2,7 @@
 |    컴포넌트 및 기능 명세서 (현재 기준)  |
 =========================================
 
-Last Reviewed: 2026-04-02
+Last Reviewed: 2026-06-05
 
 이 문서는 현재 코드 기준으로 주요 컴포넌트와 책임을 정리한다.
 
@@ -51,6 +51,8 @@ Last Reviewed: 2026-04-02
 *   책임:
     *   `.slice` 로드
     *   `.slice` 메타에서 box dimensions 복원
+    *   box dimensions 누락 시 단일 처리용 수동 입력 / `.slice` 메타 저장 옵션 제공
+    *   batch processing에서 파일별 `.slice` 메타 box dimensions 사용, 누락 파일은 파일별 실패 처리
     *   Result Resampling / 선택 구간 Result Resampling / processing mode / advanced settings 수집
     *   processing 실행 요청
     *   `.proc` 저장

--- a/docs/analysis/design/gui_overview.md
+++ b/docs/analysis/design/gui_overview.md
@@ -1,6 +1,6 @@
 # Box Motion Analyzer v2.2 GUI 구조 설명서
 
-Last Reviewed: 2026-04-02
+Last Reviewed: 2026-06-05
 
 ## 개요
 이 문서는 현재 구현된 분석 GUI의 구조를 설명한다. 기준 코드는 `src/analysis/app/main_window.py`, `src/analysis/ui/widget_raw_data_processing.py`, `src/analysis/ui/widget_slice_processing.py`, `src/analysis/ui/widget_results_analyzer.py`이다.
@@ -64,6 +64,8 @@ Last Reviewed: 2026-04-02
     - padded range
   - `Box Dimensions (mm)`
     - `.slice` 메타에 저장된 box 치수를 읽어 자동으로 채운다
+    - 기본적으로 입력은 비활성화한다
+    - `.slice` 메타에 box 치수가 없으면 경고를 띄우고, 단일 처리에 한해 임시 수동 입력과 `.slice` 메타 저장 옵션을 제공한다
   - 로그 출력 텍스트 영역
 
 ### 3.2. 하단 컨트롤
@@ -86,6 +88,7 @@ Last Reviewed: 2026-04-02
 ### 3.3. 주요 동작
 - `.slice`를 열면 `DataLoader.load_csv()`와 `Parser.process()`를 다시 사용해 parsed slice를 준비한다.
 - processing은 `PipelineController.run_analysis_from_parsed()`를 통해 실행한다.
+- batch processing은 각 `.slice` 파일의 box 치수를 파일별 메타에서 읽어 사용하며, box 치수가 없는 파일은 해당 파일만 실패 처리한다.
 - 완료된 결과는 Step 1.5 내부에서 확인한 뒤 `.proc`로 저장한다.
 
 ## 4. Step 2: Results Analysis

--- a/src/analysis/pipeline/artifact_io.py
+++ b/src/analysis/pipeline/artifact_io.py
@@ -230,6 +230,45 @@ def read_slice_metadata(filepath: str) -> SliceMetadata:
     )
 
 
+def update_slice_box_dimensions(filepath: str, box_dims: tuple[float, float, float] | list[float]) -> SliceMetadata:
+    if box_dims is None or len(box_dims) != 3:
+        raise ValueError("Box dimensions must include L, W, and H.")
+
+    normalized_dims = tuple(float(value) for value in box_dims)
+    if any(value <= 0 for value in normalized_dims):
+        raise ValueError("Box dimensions must be positive values.")
+
+    with open(filepath, mode="r", encoding="utf-8-sig", newline="") as infile:
+        rows = list(csv.reader(infile))
+
+    if not rows:
+        raise ValueError(f"Invalid slice file header: {filepath}")
+
+    prefix_meta = _parse_metadata_row(rows[0])
+    magic = prefix_meta.get("magic") or (rows[0][0].strip() if rows[0] else "")
+    if magic != SLICE_FILE_MAGIC:
+        raise ValueError(f"Invalid slice file header: {filepath}")
+
+    while len(rows) < 2:
+        rows.append([])
+
+    detail_meta = _parse_metadata_row(rows[1])
+    detail_meta.update(
+        {
+            "box_l": normalized_dims[0],
+            "box_w": normalized_dims[1],
+            "box_h": normalized_dims[2],
+        }
+    )
+    rows[1] = _metadata_row_from_mapping(detail_meta, SLICE_META_DETAIL_KEYS)
+
+    with open(filepath, mode="w", encoding="utf-8", newline="") as outfile:
+        writer = csv.writer(outfile)
+        writer.writerows(rows)
+
+    return read_slice_metadata(filepath)
+
+
 def save_slice_file(
     *,
     filepath: str,

--- a/src/analysis/pipeline/pipeline_controller.py
+++ b/src/analysis/pipeline/pipeline_controller.py
@@ -39,7 +39,22 @@ class PipelineController(QObject):
             return self._execute_result_resampling(gui_config, parsed_data)
         return self._execute_analysis_single_pass(gui_config, parsed_data)
 
+    def _apply_box_dimensions_from_config(self, gui_config: dict) -> None:
+        box_dims = gui_config.get('box_dimensions')
+        if box_dims is None:
+            return
+
+        normalized_dims = np.array(box_dims, dtype=float)
+        if normalized_dims.shape != (3,) or np.any(normalized_dims <= 0):
+            raise ValueError("Box dimensions must include positive L, W, and H values.")
+
+        config_app.BOX_DIMS = normalized_dims
+        config_app.LOCAL_BOX_CORNERS = config_app.calculate_local_box_corners(normalized_dims)
+        self.pose_optimizer.local_box_corners = config_app.LOCAL_BOX_CORNERS
+        self.velocity_calculator.local_box_corners = config_app.LOCAL_BOX_CORNERS
+
     def _execute_analysis_single_pass(self, gui_config: dict, parsed_data: pd.DataFrame) -> pd.DataFrame:
+        self._apply_box_dimensions_from_config(gui_config)
         analysis_options = gui_config.get('analysis_options', {})
         processing_mode = gui_config.get('processing_mode', 'standard')
         effective_analysis_options = build_effective_analysis_options(analysis_options, 1)

--- a/src/analysis/ui/widget_slice_processing.py
+++ b/src/analysis/ui/widget_slice_processing.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
     QApplication,
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLabel,
     QLineEdit, QComboBox, QTextEdit, QGroupBox, QGridLayout, QFileDialog, QRadioButton, QCheckBox,
-    QSizePolicy, QSplitter
+    QMessageBox, QSizePolicy, QSplitter
 )
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
@@ -22,6 +22,7 @@ from src.analysis.pipeline.artifact_io import (
     read_slice_metadata,
     slice_file_filter,
     save_proc_file,
+    update_slice_box_dimensions,
 )
 from src.analysis.pipeline.pipeline_controller import PipelineController
 from src.analysis.ui.data_selection_dialog import DataSelectionDialog
@@ -51,6 +52,7 @@ class WidgetSliceProcessing(QWidget):
         self.current_processed_result = None
         self.current_proc_path = None
         self.batch_slice_folder = None
+        self.manual_box_dimensions = None
         self.pipeline_controller_factory = PipelineController
 
         self._setup_ui()
@@ -129,6 +131,15 @@ class WidgetSliceProcessing(QWidget):
         self.box_dims_warning.setWordWrap(True)
         self.box_dims_warning.setStyleSheet("color: #666666;")
         box_dims_layout.addWidget(self.box_dims_warning, 3, 0, 1, 2)
+
+        self.save_box_dims_to_slice_checkbox = QCheckBox("Save dimensions to this .slice")
+        self.save_box_dims_to_slice_checkbox.setVisible(False)
+        box_dims_layout.addWidget(self.save_box_dims_to_slice_checkbox, 4, 0, 1, 2)
+
+        self.apply_box_dims_button = QPushButton("Apply Dimensions")
+        self.apply_box_dims_button.setVisible(False)
+        self.apply_box_dims_button.setEnabled(False)
+        box_dims_layout.addWidget(self.apply_box_dims_button, 5, 0, 1, 2)
         
         right_panel_layout.addWidget(self.box_dims_group)
 
@@ -325,6 +336,7 @@ class WidgetSliceProcessing(QWidget):
         self.rb_processing_raw.toggled.connect(self._on_processing_mode_changed)
         self.rb_processing_advanced.toggled.connect(self._on_processing_mode_changed)
         self.processing_settings_button.clicked.connect(self.open_processing_settings_dialog)
+        self.apply_box_dims_button.clicked.connect(self.apply_manual_box_dimensions)
         self.run_button.clicked.connect(self.emit_run_processing)
         self.save_proc_button.clicked.connect(self.save_processed_result)
         self.select_slice_folder_button.clicked.connect(self.select_slice_folder)
@@ -392,17 +404,110 @@ class WidgetSliceProcessing(QWidget):
             raise ValueError("Result resampling range must stay inside the slice user range.")
         return range_start, range_end
 
+    def _metadata_has_box_dimensions(self, metadata) -> bool:
+        return (
+            metadata is not None
+            and metadata.box_l is not None
+            and metadata.box_w is not None
+            and metadata.box_h is not None
+        )
+
+    def _box_dimensions_from_metadata(self, metadata) -> tuple[float, float, float]:
+        if not self._metadata_has_box_dimensions(metadata):
+            raise ValueError("Missing box dimensions in slice metadata.")
+        box_dims = (float(metadata.box_l), float(metadata.box_w), float(metadata.box_h))
+        if any(value <= 0 for value in box_dims):
+            raise ValueError("Box dimensions in slice metadata must be positive values.")
+        return box_dims
+
+    def _set_box_dimension_inputs_enabled(self, enabled: bool):
+        self.le_box_l.setEnabled(enabled)
+        self.le_box_w.setEnabled(enabled)
+        self.le_box_h.setEnabled(enabled)
+
+    def _reset_box_dimension_state(self):
+        self.manual_box_dimensions = None
+        self._set_box_dimension_inputs_enabled(False)
+        self.apply_box_dims_button.setEnabled(False)
+        self.apply_box_dims_button.setVisible(False)
+        self.save_box_dims_to_slice_checkbox.setChecked(False)
+        self.save_box_dims_to_slice_checkbox.setVisible(False)
+        self.box_dims_warning.setText(
+            "These values were defined in Step 1 and imported from the .slice file."
+        )
+        self.box_dims_warning.setStyleSheet("color: #666666;")
+
+    def _enter_missing_box_dimension_mode(self):
+        self.manual_box_dimensions = None
+        self._set_box_dimension_inputs_enabled(True)
+        self.apply_box_dims_button.setEnabled(True)
+        self.apply_box_dims_button.setVisible(True)
+        self.save_box_dims_to_slice_checkbox.setVisible(True)
+        self.box_dims_warning.setText(
+            "Box dimensions are missing from this .slice. Enter L/W/H before processing."
+        )
+        self.box_dims_warning.setStyleSheet("color: #b45309;")
+        self.run_button.setEnabled(False)
+
+    def _read_box_dimensions_from_inputs(self) -> tuple[float, float, float]:
+        try:
+            box_dims = (
+                float(self.le_box_l.text()),
+                float(self.le_box_w.text()),
+                float(self.le_box_h.text()),
+            )
+        except ValueError:
+            raise ValueError("Enter numeric box dimensions for L, W, and H.")
+        if any(value <= 0 for value in box_dims):
+            raise ValueError("Box dimensions must be positive values.")
+        return box_dims
+
     def _apply_box_dims_from_metadata(self, metadata=None):
         metadata = self.slice_metadata if metadata is None else metadata
         if metadata is None:
             return
 
-        if metadata.box_l is not None:
+        if self._metadata_has_box_dimensions(metadata):
             self.le_box_l.setText(f"{metadata.box_l:g}")
-        if metadata.box_w is not None:
             self.le_box_w.setText(f"{metadata.box_w:g}")
-        if metadata.box_h is not None:
             self.le_box_h.setText(f"{metadata.box_h:g}")
+            return
+
+        self.le_box_l.setText("" if metadata.box_l is None else f"{metadata.box_l:g}")
+        self.le_box_w.setText("" if metadata.box_w is None else f"{metadata.box_w:g}")
+        self.le_box_h.setText("" if metadata.box_h is None else f"{metadata.box_h:g}")
+
+    def apply_manual_box_dimensions(self):
+        try:
+            box_dims = self._read_box_dimensions_from_inputs()
+            if self.save_box_dims_to_slice_checkbox.isChecked():
+                if not self.slice_path:
+                    raise ValueError("No slice file is loaded.")
+                self.slice_metadata = update_slice_box_dimensions(self.slice_path, box_dims)
+                self._apply_box_dims_from_metadata(self.slice_metadata)
+                self.append_log(
+                    "[INFO] Box dimensions saved to slice metadata: "
+                    f"L={box_dims[0]:g}, W={box_dims[1]:g}, H={box_dims[2]:g}"
+                )
+            else:
+                self.manual_box_dimensions = box_dims
+                self.append_log(
+                    "[INFO] Box dimensions applied for this processing session: "
+                    f"L={box_dims[0]:g}, W={box_dims[1]:g}, H={box_dims[2]:g}"
+                )
+
+            self._set_box_dimension_inputs_enabled(False)
+            self.apply_box_dims_button.setEnabled(False)
+            self.apply_box_dims_button.setVisible(False)
+            self.save_box_dims_to_slice_checkbox.setVisible(False)
+            self.box_dims_warning.setText(
+                "These values are ready for processing. Load another .slice to reset this state."
+            )
+            self.box_dims_warning.setStyleSheet("color: #666666;")
+            self.run_button.setEnabled(self.parsed_data is not None)
+        except Exception as e:
+            QMessageBox.warning(self, "Box Dimensions Required", str(e))
+            self.append_log(f"[ERROR] Invalid box dimensions: {e}")
 
     def _load_slice_bundle(self, filepath: str):
         metadata = read_slice_metadata(filepath)
@@ -417,6 +522,7 @@ class WidgetSliceProcessing(QWidget):
 
     def load_slice_file(self, filepath: str):
         try:
+            self._reset_box_dimension_state()
             self.slice_metadata, self.header_info, self.raw_data, self.parsed_data = self._load_slice_bundle(filepath)
             self.slice_path = filepath
             self.slice_path_label.setText(filepath)
@@ -427,7 +533,7 @@ class WidgetSliceProcessing(QWidget):
             self.proc_path_label.setText("Not saved yet.")
             self.result_status_label.setText("Ready to process.")
             self.save_proc_button.setEnabled(False)
-            self.run_button.setEnabled(True)
+            self.run_button.setEnabled(self._metadata_has_box_dimensions(self.slice_metadata))
 
             all_targets = self.data_loader.get_plottable_targets(self.parsed_data)
             if DisplayNames.RB_CENTER in all_targets:
@@ -442,16 +548,21 @@ class WidgetSliceProcessing(QWidget):
 
             self.update_plot()
             self.append_log(f"[INFO] Loaded slice file: {filepath}")
-            if (
-                self.slice_metadata.box_l is not None and
-                self.slice_metadata.box_w is not None and
-                self.slice_metadata.box_h is not None
-            ):
+            if self._metadata_has_box_dimensions(self.slice_metadata):
                 self.append_log(
                     "[INFO] Box dimensions restored from slice metadata: "
                     f"L={self.slice_metadata.box_l:g}, "
                     f"W={self.slice_metadata.box_w:g}, "
                     f"H={self.slice_metadata.box_h:g}"
+                )
+            else:
+                self._enter_missing_box_dimension_mode()
+                self.append_log("[WARNING] Box dimensions are missing from slice metadata.")
+                QMessageBox.warning(
+                    self,
+                    "Box Dimensions Required",
+                    "This .slice file does not include complete box dimensions. "
+                    "Enter L/W/H before processing, or return to Step 1 and save a new .slice file.",
                 )
             self.append_log("[INFO] Slice parsed and ready for processing.")
         except Exception as e:
@@ -534,26 +645,15 @@ class WidgetSliceProcessing(QWidget):
             return config_analysis_ui.get_raw_mode_options()
         return dict(self.advanced_processing_options)
 
-    def _get_current_box_dimensions(self) -> tuple[float, float, float]:
-        return (
-            float(self.le_box_l.text()),
-            float(self.le_box_w.text()),
-            float(self.le_box_h.text()),
-        )
-
-    def _set_box_dimensions(self, box_dims: tuple[float, float, float]):
-        config_app.BOX_DIMS = [float(box_dims[0]), float(box_dims[1]), float(box_dims[2])]
-
     def _resolve_box_dimensions(self, metadata=None) -> tuple[float, float, float]:
         metadata = self.slice_metadata if metadata is None else metadata
-        if (
-            metadata is not None
-            and metadata.box_l is not None
-            and metadata.box_w is not None
-            and metadata.box_h is not None
-        ):
-            return (float(metadata.box_l), float(metadata.box_w), float(metadata.box_h))
-        return self._get_current_box_dimensions()
+        if self._metadata_has_box_dimensions(metadata):
+            return self._box_dimensions_from_metadata(metadata)
+        if self.manual_box_dimensions is not None:
+            return self.manual_box_dimensions
+        raise ValueError(
+            "Box dimensions are missing. Apply manual dimensions or save a new .slice file from Step 1."
+        )
 
     def _build_timeline_context(self, metadata=None) -> dict:
         metadata = self.slice_metadata if metadata is None else metadata
@@ -568,9 +668,10 @@ class WidgetSliceProcessing(QWidget):
             "slice_end_sec": slice_end,
         }
 
-    def _build_processing_config(self, parsed_data, metadata=None) -> dict:
+    def _build_processing_config(self, parsed_data, metadata=None, box_dims=None) -> dict:
         metadata = self.slice_metadata if metadata is None else metadata
         range_start, range_end = self._get_resampling_range_values(parsed_data, metadata)
+        resolved_box_dims = self._resolve_box_dimensions(metadata) if box_dims is None else box_dims
         return {
             "slice_filter_by": "time",
             "slice_start_val": (
@@ -590,13 +691,13 @@ class WidgetSliceProcessing(QWidget):
             "result_resampling_range_end": range_end,
             "processing_mode": self.current_processing_mode,
             "analysis_options": self._build_analysis_overrides(),
+            "box_dimensions": tuple(float(value) for value in resolved_box_dims),
         }
 
     def emit_run_processing(self):
         if self.parsed_data is None:
             return
         try:
-            self._set_box_dimensions(self._get_current_box_dimensions())
             config = self._build_processing_config(self.parsed_data, self.slice_metadata)
             self.run_button.setEnabled(False)
             self.save_proc_button.setEnabled(False)
@@ -672,7 +773,8 @@ class WidgetSliceProcessing(QWidget):
         processed_count = 0
         skipped_count = 0
         failed_count = 0
-        original_box_dims = list(config_app.BOX_DIMS)
+        original_box_dims = config_app.BOX_DIMS.copy()
+        original_local_box_corners = config_app.LOCAL_BOX_CORNERS.copy()
 
         self._set_batch_controls_enabled(False)
         self.save_proc_button.setEnabled(False)
@@ -699,9 +801,9 @@ class WidgetSliceProcessing(QWidget):
 
                 try:
                     metadata, _, _, parsed_data = self._load_slice_bundle(slice_path)
-                    self._set_box_dimensions(self._resolve_box_dimensions(metadata))
+                    box_dims = self._box_dimensions_from_metadata(metadata)
                     processed_df = controller.process_parsed_data(
-                        self._build_processing_config(parsed_data, metadata),
+                        self._build_processing_config(parsed_data, metadata, box_dims=box_dims),
                         parsed_data,
                     )
                     processed_with_context = add_timeline_context_columns(
@@ -716,6 +818,7 @@ class WidgetSliceProcessing(QWidget):
                     self.append_log(f"[ERROR] Batch processing failed for {slice_path}: {e}")
         finally:
             config_app.BOX_DIMS = original_box_dims
+            config_app.LOCAL_BOX_CORNERS = original_local_box_corners
             self._set_batch_controls_enabled(True)
 
         summary = (

--- a/src/config/config_app.py
+++ b/src/config/config_app.py
@@ -26,23 +26,26 @@ BOX_DIMS = np.array([1578.0, 930.0, 142.0]) # Width, Height, Depth in (mm) for l
 # BOX_DIMS = np.array([1820.0, 1110.0, 164.0]) # L, W, H in (mm) corresponding to local X, Y, Z axes
 
 # --- Derived Box Geometry (calculated from BOX_DIMS) ---
-_L_box, _W_box, _H_box = BOX_DIMS # Unpack for clarity in local corner/edge definitions
-_hl, _hw, _hh = _L_box / 2.0, _W_box / 2.0, _H_box / 2.0
+def calculate_local_box_corners(box_dims):
+    dims = np.array(box_dims, dtype=float)
+    _L_box, _W_box, _H_box = dims # Unpack for clarity in local corner/edge definitions
+    _hl, _hw, _hh = _L_box / 2.0, _W_box / 2.0, _H_box / 2.0
+    return np.array([
+        [-_hl, -_hw, -_hh], # 0
+        [ _hl, -_hw, -_hh], # 1
+        [ _hl,  _hw, -_hh], # 2
+        [-_hl,  _hw, -_hh], # 3
+        [-_hl, -_hw,  _hh], # 4
+        [ _hl, -_hw,  _hh], # 5
+        [ _hl,  _hw,  _hh], # 6
+        [-_hl,  _hw,  _hh]  # 7
+    ])
 
 # Standard 8 local corners, ordered for consistency.
 # Origin at box center. Axes: X (Width), Y (Height), Z (Depth).
 # This order matches the one historically used in AlignBoxMain's get_box_world_corners
 # and is critical for FACE_DEFINITIONS.
-LOCAL_BOX_CORNERS = np.array([
-    [-_hl, -_hw, -_hh], # 0
-    [ _hl, -_hw, -_hh], # 1
-    [ _hl,  _hw, -_hh], # 2
-    [-_hl,  _hw, -_hh], # 3
-    [-_hl, -_hw,  _hh], # 4
-    [ _hl, -_hw,  _hh], # 5
-    [ _hl,  _hw,  _hh], # 6
-    [-_hl,  _hw,  _hh]  # 7
-])
+LOCAL_BOX_CORNERS = calculate_local_box_corners(BOX_DIMS)
 
 # Box edges defined by pairs of corner indices from LOCAL_BOX_CORNERS
 # This order is for drawing a typical box wireframe.

--- a/tests/test_artifact_io_filters.py
+++ b/tests/test_artifact_io_filters.py
@@ -1,3 +1,4 @@
+import csv
 import os
 import tempfile
 import unittest
@@ -5,6 +6,7 @@ import unittest
 from src.analysis.pipeline.artifact_io import (
     PROC_FILE_EXTENSION,
     SLICE_FILE_EXTENSION,
+    SLICE_FILE_MAGIC,
     build_batch_proc_path,
     is_result_file,
     is_slice_file,
@@ -12,8 +14,10 @@ from src.analysis.pipeline.artifact_io import (
     list_slice_files,
     proc_file_filter,
     raw_csv_file_filter,
+    read_slice_metadata,
     result_file_filter,
     slice_file_filter,
+    update_slice_box_dimensions,
 )
 
 
@@ -51,6 +55,42 @@ class TestArtifactIoFilters(unittest.TestCase):
 
             self.assertEqual(PROC_FILE_EXTENSION, ".proc")
             self.assertEqual(SLICE_FILE_EXTENSION, ".slice")
+
+    def test_update_slice_box_dimensions_updates_metadata_and_preserves_rows(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            slice_path = os.path.join(temp_dir, "scene.slice")
+            with open(slice_path, "w", encoding="utf-8", newline="") as handle:
+                writer = csv.writer(handle)
+                writer.writerow([f"magic={SLICE_FILE_MAGIC}", "version=1", "source=source.csv", "created=test"])
+                writer.writerow(
+                    [
+                        "scene=scene",
+                        "box_l=",
+                        "box_w=",
+                        "box_h=",
+                        "full_start=0.0",
+                        "full_end=1.0",
+                        "user_start=0.1",
+                        "user_end=0.9",
+                        "padded_start=0.0",
+                        "padded_end=1.0",
+                        "pad_rows=50",
+                        "row_count=1",
+                    ]
+                )
+                writer.writerow(["type", "name"])
+                writer.writerow(["data", "row"])
+
+            metadata = update_slice_box_dimensions(slice_path, (10.0, 20.0, 30.0))
+            reread_metadata = read_slice_metadata(slice_path)
+
+            self.assertEqual((metadata.box_l, metadata.box_w, metadata.box_h), (10.0, 20.0, 30.0))
+            self.assertEqual((reread_metadata.box_l, reread_metadata.box_w, reread_metadata.box_h), (10.0, 20.0, 30.0))
+
+            with open(slice_path, "r", encoding="utf-8", newline="") as handle:
+                rows = list(csv.reader(handle))
+            self.assertEqual(rows[-2], ["type", "name"])
+            self.assertEqual(rows[-1], ["data", "row"])
 
 
 if __name__ == "__main__":

--- a/tests/test_slice_batch_processing.py
+++ b/tests/test_slice_batch_processing.py
@@ -33,8 +33,10 @@ class _FakePipelineController:
     def __init__(self, result_df):
         self.log_message = _DummySignal()
         self._result_df = result_df
+        self.configs = []
 
     def process_parsed_data(self, config, parsed_data):
+        self.configs.append(config)
         self.log_message.emit("[INFO] Fake batch processing run.")
         return self._result_df.copy()
 
@@ -61,6 +63,24 @@ class TestSliceBatchProcessing(unittest.TestCase):
             box_l=1.0,
             box_w=2.0,
             box_h=3.0,
+            full_start=0.0,
+            full_end=1.0,
+            user_start=0.1,
+            user_end=0.9,
+            padded_start=0.0,
+            padded_end=1.0,
+            pad_rows=50,
+            row_count=100,
+        )
+
+    def _metadata_without_box_dimensions(self):
+        return SliceMetadata(
+            source="source.csv",
+            created="2026-03-18T00:00:00+00:00",
+            scene="scene",
+            box_l=None,
+            box_w=None,
+            box_h=None,
             full_start=0.0,
             full_end=1.0,
             user_start=0.1,
@@ -121,6 +141,7 @@ class TestSliceBatchProcessing(unittest.TestCase):
         self.assertTrue(config["limit_result_resampling_to_range"])
         self.assertEqual(config["result_resampling_range_start"], 0.2)
         self.assertEqual(config["result_resampling_range_end"], 0.8)
+        self.assertEqual(config["box_dimensions"], (1.0, 2.0, 3.0))
 
     def test_slice_summary_sets_default_resampling_range_from_metadata(self):
         self.widget.slice_metadata = self._metadata()
@@ -129,6 +150,129 @@ class TestSliceBatchProcessing(unittest.TestCase):
 
         self.assertEqual(self.widget.le_resampling_range_start.text(), "0.100")
         self.assertEqual(self.widget.le_resampling_range_end.text(), "0.900")
+
+    def test_missing_slice_box_dimensions_enable_manual_apply_until_valid(self):
+        self.widget.data_loader.get_plottable_targets.return_value = []
+
+        with patch.object(
+            self.widget,
+            "_load_slice_bundle",
+            return_value=(self._metadata_without_box_dimensions(), {}, pd.DataFrame(), pd.DataFrame(index=[0.0, 0.1])),
+        ), patch("src.analysis.ui.widget_slice_processing.QMessageBox.warning") as mock_warning:
+            self.widget.load_slice_file("missing.slice")
+
+        mock_warning.assert_called_once()
+        self.assertTrue(self.widget.le_box_l.isEnabled())
+        self.assertFalse(self.widget.apply_box_dims_button.isHidden())
+        self.assertFalse(self.widget.run_button.isEnabled())
+
+        self.widget.le_box_l.setText("10")
+        self.widget.le_box_w.setText("20")
+        self.widget.le_box_h.setText("30")
+        self.widget.apply_manual_box_dimensions()
+
+        self.assertEqual(self.widget.manual_box_dimensions, (10.0, 20.0, 30.0))
+        self.assertFalse(self.widget.le_box_l.isEnabled())
+        self.assertTrue(self.widget.apply_box_dims_button.isHidden())
+        self.assertTrue(self.widget.run_button.isEnabled())
+
+    def test_manual_box_dimensions_can_be_saved_to_slice_metadata(self):
+        self.widget.data_loader.get_plottable_targets.return_value = []
+        updated_metadata = self._metadata()
+
+        with patch.object(
+            self.widget,
+            "_load_slice_bundle",
+            return_value=(self._metadata_without_box_dimensions(), {}, pd.DataFrame(), pd.DataFrame(index=[0.0, 0.1])),
+        ), patch("src.analysis.ui.widget_slice_processing.QMessageBox.warning"):
+            self.widget.load_slice_file("missing.slice")
+
+        self.widget.le_box_l.setText("10")
+        self.widget.le_box_w.setText("20")
+        self.widget.le_box_h.setText("30")
+        self.widget.save_box_dims_to_slice_checkbox.setChecked(True)
+
+        with patch(
+            "src.analysis.ui.widget_slice_processing.update_slice_box_dimensions",
+            return_value=updated_metadata,
+        ) as mock_update:
+            self.widget.apply_manual_box_dimensions()
+
+        mock_update.assert_called_once_with("missing.slice", (10.0, 20.0, 30.0))
+        self.assertEqual(self.widget.slice_metadata, updated_metadata)
+        self.assertIsNone(self.widget.manual_box_dimensions)
+        self.assertTrue(self.widget.run_button.isEnabled())
+
+    def test_batch_processing_uses_each_slice_metadata_dimensions(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            slice_a = os.path.join(temp_dir, "scene_a.slice")
+            slice_b = os.path.join(temp_dir, "scene_b.slice")
+            open(slice_a, "w", encoding="utf-8").close()
+            open(slice_b, "w", encoding="utf-8").close()
+
+            self.widget.batch_slice_folder = temp_dir
+            fake_controller = _FakePipelineController(pd.DataFrame({"metric": [1.0, 2.0]}))
+            metadata_a = self._metadata()
+            metadata_b = SliceMetadata(
+                source="source.csv",
+                created="2026-03-18T00:00:00+00:00",
+                scene="scene",
+                box_l=4.0,
+                box_w=5.0,
+                box_h=6.0,
+                full_start=0.0,
+                full_end=1.0,
+                user_start=0.1,
+                user_end=0.9,
+                padded_start=0.0,
+                padded_end=1.0,
+                pad_rows=50,
+                row_count=100,
+            )
+            self.widget.pipeline_controller_factory = lambda: fake_controller
+
+            with patch.object(
+                self.widget,
+                "_load_slice_bundle",
+                side_effect=[
+                    (metadata_a, {}, pd.DataFrame(), pd.DataFrame(index=[0.0, 0.1])),
+                    (metadata_b, {}, pd.DataFrame(), pd.DataFrame(index=[0.0, 0.1])),
+                ],
+            ), patch("src.analysis.ui.widget_slice_processing.save_proc_file"):
+                self.widget.run_batch_processing()
+
+            self.assertEqual(
+                [config["box_dimensions"] for config in fake_controller.configs],
+                [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)],
+            )
+            self.assertIn("processed=2", self.widget.batch_summary_label.text())
+            self.assertIn("failed=0", self.widget.batch_summary_label.text())
+
+    def test_batch_processing_fails_missing_dimensions_per_file_and_continues(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            slice_a = os.path.join(temp_dir, "scene_a.slice")
+            slice_b = os.path.join(temp_dir, "scene_b.slice")
+            open(slice_a, "w", encoding="utf-8").close()
+            open(slice_b, "w", encoding="utf-8").close()
+
+            self.widget.batch_slice_folder = temp_dir
+            fake_controller = _FakePipelineController(pd.DataFrame({"metric": [1.0, 2.0]}))
+            self.widget.pipeline_controller_factory = lambda: fake_controller
+
+            with patch.object(
+                self.widget,
+                "_load_slice_bundle",
+                side_effect=[
+                    (self._metadata_without_box_dimensions(), {}, pd.DataFrame(), pd.DataFrame(index=[0.0, 0.1])),
+                    (self._metadata(), {}, pd.DataFrame(), pd.DataFrame(index=[0.0, 0.1])),
+                ],
+            ), patch("src.analysis.ui.widget_slice_processing.save_proc_file") as mock_save_proc:
+                self.widget.run_batch_processing()
+
+            self.assertEqual([config["box_dimensions"] for config in fake_controller.configs], [(1.0, 2.0, 3.0)])
+            mock_save_proc.assert_called_once()
+            self.assertIn("processed=1", self.widget.batch_summary_label.text())
+            self.assertIn("failed=1", self.widget.batch_summary_label.text())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
English
- Summary
  Fix Step 1.5 processing so box dimensions come from .slice metadata, with a controlled manual fallback only for incomplete .slice files.

- Changes
  Keep Step 1.5 box dimension fields read-only for normal .slice files.
  Show a warning and temporary manual input flow when a .slice is missing box dimensions.
  Add an option to save manually entered dimensions back to the .slice metadata.
  Make batch processing use each .slice file's own box dimensions and fail only files with missing metadata.
  Pass box dimensions through the processing config and update runtime box geometry consistently.

- Testing
  Ran:
  QT_QPA_PLATFORM=offscreen python -m unittest tests.test_slice_batch_processing tests.test_artifact_io_filters tests.test_coordinate_config_consistency
  python -m py_compile src/analysis/pipeline/artifact_io.py src/analysis/pipeline/pipeline_controller.py src/analysis/ui/widget_slice_processing.py src/config/config_app.py
  git diff --check

- Risks / Notes
  Full unittest discovery was blocked by the existing VTK/OpenGL initialization failure in the visualization tests.
  Existing untracked data/sim_data.csv and .codex-remote-attachments/ were left untouched.

한국어
- 요약
  Step 1.5 processing에서 box dimensions가 .slice 메타를 기준으로 적용되도록 수정하고, 메타가 없는 .slice에만 제한적으로 수동 보정 흐름을 제공합니다.

- 변경 사항
  정상 .slice 파일에서는 Step 1.5 box dimension 입력칸을 읽기 전용으로 유지합니다.
  .slice에 box dimension이 없으면 경고를 띄우고 임시 수동 입력을 허용합니다.
  수동 입력한 값을 .slice 메타에 저장하는 옵션을 추가했습니다.
  batch processing은 각 .slice 파일의 box dimensions를 파일별로 사용하고, 메타가 없는 파일만 실패 처리합니다.
  processing config를 통해 box dimensions를 전달하고 runtime box geometry도 같은 값으로 갱신합니다.

- 테스트
  실행:
  QT_QPA_PLATFORM=offscreen python -m unittest tests.test_slice_batch_processing tests.test_artifact_io_filters tests.test_coordinate_config_consistency
  python -m py_compile src/analysis/pipeline/artifact_io.py src/analysis/pipeline/pipeline_controller.py src/analysis/ui/widget_slice_processing.py src/config/config_app.py
  git diff --check

- 리스크 / 참고사항
  전체 unittest discovery는 visualization 테스트의 기존 VTK/OpenGL 초기화 실패로 중단되었습니다.
  기존 untracked 파일 data/sim_data.csv와 .codex-remote-attachments/는 건드리지 않았습니다.